### PR TITLE
force word alignment for string buffer.

### DIFF
--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -794,13 +794,12 @@ class gapmer {
  public:
   gapmer() : data_(0) {}
 
-  gapmer(const char* s, uint8_t k) : data_(0) {
+  gapmer(const uint64_t* d_ptr, uint8_t k) : data_(0) {
 #ifdef DEBUG
     assert(k > 0);
     assert(k <= 24);
 #endif
     uint64_t iv;
-    const uint64_t* d_ptr = reinterpret_cast<const uint64_t*>(s);
     for (uint16_t i = 0; i < max_k / 8; ++i) {
       iv = __bswap_64(d_ptr[i]);
       iv = _pext_u64(iv, pext_mask);
@@ -827,10 +826,10 @@ class gapmer {
     data_ |= uint64_t(k) << (max_k * 2);
   }
 
-  gapmer(const char* s, uint8_t k, uint8_t gap_start, uint8_t gap_length)
+  gapmer(const uint64_t* d_ptr, uint8_t k, uint8_t gap_start, uint8_t gap_length)
       : data_(0) {
     if (gap_start == 0) {
-      *this = gapmer(s, k);
+      *this = gapmer(d_ptr, k);
       return;
     }
 #ifdef DEBUG
@@ -842,7 +841,7 @@ class gapmer {
 #endif
 
     uint64_t iv;
-    const uint64_t* d_ptr = reinterpret_cast<const uint64_t*>(s);
+    const char* s = reinterpret_cast<const char*>(d_ptr);
     for (uint16_t i = 0; i < max_k / 8; ++i) {
       iv = __bswap_64(d_ptr[i]);
       iv = _pext_u64(iv, pext_mask);

--- a/include/gapmer_count.hpp
+++ b/include/gapmer_count.hpp
@@ -76,7 +76,7 @@ class gapmer_count {
       if (len == 0) {
         break;
       }
-      gapmer<middle_gap_only, max_gap> g(s, k);
+      gapmer<middle_gap_only, max_gap> g(buf, k);
       uint64_t cv = g.value();
 #pragma omp atomic
       counts[cv] = counts[cv] + 1;
@@ -95,7 +95,7 @@ class gapmer_count {
             break;
           }
           uint64_t off = offset(k, gap_s, gap_l);
-          g = {s, k, gap_s, gap_l};
+          g = {buf, k, gap_s, gap_l};
           cv = off + g.value();
 #pragma omp atomic
           counts[cv] = counts[cv] + 1;

--- a/test/gapmer_tests.hpp
+++ b/test/gapmer_tests.hpp
@@ -3,9 +3,20 @@
 #include <string>
 
 namespace sf {
+
+std::vector<uint64_t> vec_from_string(const std::string& s) {
+  std::vector<uint64_t> vec(10);
+  char* ptr = reinterpret_cast<char*>(vec.data());
+  for (uint16_t i = 0; i < s.size(); ++i) {
+    ptr[i] = s[i];
+  }
+  return vec;
+}
+
 TEST(gapmer, StrConstructor1) {
   std::string s = "TTTTTTTT";
-  gapmer g(s.c_str(), 8);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
   ASSERT_TRUE(g.is_valid());
   auto sm = g.to_string();
   ASSERT_EQ(sm, s);
@@ -13,7 +24,8 @@ TEST(gapmer, StrConstructor1) {
 
 TEST(gapmer, StrConstructor2) {
   std::string s = "TTT..TTT";
-  gapmer g(s.c_str(), 6, 3, 2);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 6, 3, 2);
   ASSERT_TRUE(g.is_valid());
   auto sm = g.to_string();
   ASSERT_EQ(sm, s);
@@ -21,7 +33,8 @@ TEST(gapmer, StrConstructor2) {
 
 TEST(gapmer, StrConstructor3) {
   std::string s = "CATTATTAC";
-  gapmer g(s.c_str(), 9, 0, 0);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 9, 0, 0);
   ASSERT_TRUE(g.is_valid());
   auto sm = g.to_string();
   ASSERT_EQ(sm, s);
@@ -29,7 +42,8 @@ TEST(gapmer, StrConstructor3) {
 
 TEST(gapmer, StrConstructor4) {
   std::string s = "ATATATATAT...CATTATTAC";
-  gapmer g(s.c_str(), 19, 10, 3);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 19, 10, 3);
   ASSERT_TRUE(g.is_valid());
   auto sm = g.to_string();
   ASSERT_EQ(sm, s);
@@ -37,7 +51,8 @@ TEST(gapmer, StrConstructor4) {
 
 TEST(gapmer, StrConstructor5) {
   std::string s = "AATGATT..........TCTGTGG";
-  gapmer<true, 10> g(s.c_str(), 14, 7, 10);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 10> g(vec.data(), 14, 7, 10);
   ASSERT_TRUE(g.is_valid()) << g.to_string() << " " << g.bits();
   auto sm = g.to_string();
   ASSERT_EQ(sm, s);
@@ -45,190 +60,229 @@ TEST(gapmer, StrConstructor5) {
 
 TEST(gapmer, NextComp1) {
   std::string s = "CATTATAC";
-  gapmer g(s.c_str(), 5);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   g = g.next(s[5]);
-  gapmer o(s.c_str() + 1, 5);
+  vec = vec_from_string(s.substr(1));
+  gapmer o(vec.data(), 5);
   ASSERT_TRUE(g.is_valid());
   ASSERT_TRUE(g == o) << g.to_string() << " <-> " << o.to_string();
 }
 
 TEST(gapmer, NextComp2) {
   std::string s = "CATTATAC";
-  gapmer g(s.c_str(), 5, 2, 1);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5, 2, 1);
   g = g.next(s[2], s[6]);
-  gapmer o(s.c_str() + 1, 5, 2, 1);
+  vec = vec_from_string(s.substr(1)); 
+  gapmer o(vec.data(), 5, 2, 1);
   ASSERT_TRUE(g.is_valid());
   ASSERT_TRUE(g == o) << g.to_string() << " <-> " << o.to_string();
 }
 
 TEST(gapmer, Neighbour1) {
   std::string s = "TTTTTTTT";
-  gapmer g(s.c_str(), 8);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
   ASSERT_FALSE(g.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour2) {
   std::string s = "TTTTTTTT";
-  gapmer g(s.c_str(), 8);
-  gapmer h(s.c_str(), 7);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
+  gapmer h(vec.data(), 7);
   ASSERT_TRUE(g.is_neighbour(h));
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour3) {
   std::string s = "TTTTTTTT";
-  gapmer g(s.c_str(), 8);
-  gapmer h(s.c_str(), 6);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
+  gapmer h(vec.data(), 6);
   ASSERT_FALSE(g.is_neighbour(h));
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour4) {
   std::string s = "TTTTTTTT";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
   std::string t = "AAAAAAAA";
-  gapmer g(s.c_str(), 8);
-  gapmer h(t.c_str(), 6);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6);
   ASSERT_FALSE(g.is_neighbour(h));
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour5) {
   std::string s = "TTTTTTTT";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8);
   std::string t = "TTTTTTAA";
-  gapmer g(s.c_str(), 8);
-  gapmer h(t.c_str(), 6);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6);
   ASSERT_FALSE(g.is_neighbour(h));
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour6) {
   std::string s = "CATTATTAC";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 9);
   std::string t = "ATTATTAC";
-  gapmer g(s.c_str(), 9);
-  gapmer h(t.c_str(), 8);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 8);
   ASSERT_TRUE(g.is_neighbour(h));
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour7) {
   std::string s = "CATTATTAC";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 9);
   std::string t = "CATTATTA";
-  gapmer g(s.c_str(), 9);
-  gapmer h(t.c_str(), 8);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 8);
   ASSERT_TRUE(g.is_neighbour(h));
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour8) {
   std::string s = "CATTATTAC";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 9);
   std::string t = "CCATTATTA";
-  gapmer g(s.c_str(), 9);
-  gapmer h(t.c_str(), 9);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 9);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour9) {
   std::string s = "CATTATTAC";
-  gapmer g(s.c_str(), 9);
-  gapmer h(s.c_str(), 8, 4, 1);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 9);
+  gapmer h(vec.data(), 8, 4, 1);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour10) {
   std::string s = "AA.AAT";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5, 2, 1);
   std::string t = "AAAA";
-  gapmer g(s.c_str(), 5, 2, 1);
-  gapmer h(t.c_str(), 4);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 4);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour11) {
   std::string s = "AC.ATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5, 2, 1);
   std::string t = "C.ATGG";
-  gapmer g(s.c_str(), 5, 2, 1);
-  gapmer h(t.c_str(), 5, 1, 1);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 5, 1, 1);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour12) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "ACTGC.T";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 6, 5, 1);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6, 5, 1);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour13) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "C...ACATG";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 6, 1, 3);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6, 1, 3);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour14) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "T.CATG";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 5, 1, 1);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 5, 1, 1);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour15) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "G.....GTGTA";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 6, 1, 5);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6, 1, 5);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour16) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "C.....GCCA";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 6, 1, 5);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 6, 1, 5);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour17) {
   std::string s = "ACATG";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5);
   std::string t = "T....GATG";
-  gapmer g(s.c_str(), 5);
-  gapmer h(t.c_str(), 5, 1, 4);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 5, 1, 4);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour18) {
   std::string s = "AA.....AAA";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 5, 2, 5);
   std::string t = "AA......AAG";
-  gapmer g(s.c_str(), 5, 2, 5);
-  gapmer h(t.c_str(), 5, 2, 6);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 5, 2, 6);
   ASSERT_TRUE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_TRUE(h.is_neighbour(g));
 }
 
 TEST(gapmer, Neighbour19) {
   std::string s = "AAAAAA";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 6);
   std::string t = "AGA.AAAA";
-  gapmer g(s.c_str(), 6);
-  gapmer h(t.c_str(), 7, 3, 1);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 7, 3, 1);
   ASSERT_FALSE(g.is_neighbour(h)) << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour(g));
 }
 
 TEST(gapmer, RCNeighbour1) {
   std::string s = "CATTA...TTACC";
-  gapmer g(s.c_str(), 10, 3, 5);
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 10, 3, 5);
   gapmer o = g.reverse_complement();
   auto callback = [&](const decltype(o)& n) {
     ASSERT_TRUE(g.is_neighbour<true>(n));
@@ -238,9 +292,11 @@ TEST(gapmer, RCNeighbour1) {
 
 TEST(gapmer, RCNeighbour2) {
   std::string s = "CAAT.TTAC";
+  auto vec = vec_from_string(s); 
+  gapmer g(vec.data(), 8, 1, 4);
   std::string t = "AAAA.AAAA";
-  gapmer g(s.c_str(), 8, 1, 4);
-  gapmer h(t.c_str(), 8, 1, 4);
+  vec = vec_from_string(t); 
+  gapmer h(vec.data(), 8, 1, 4);
   ASSERT_FALSE(g.is_neighbour<true>(h))
       << g.to_string() << " <-> " << h.to_string();
   ASSERT_FALSE(h.is_neighbour<true>(g));
@@ -248,166 +304,188 @@ TEST(gapmer, RCNeighbour2) {
 
 TEST(gapmer, Huddinge1) {
   std::string s = "ACGTGT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 6);
+  G g(vec.data(), 6);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge2) {
   std::string s = "A.GTGT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 1, 1);
+  G g(vec.data(), 5, 1, 1);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge3) {
   std::string s = "ACGT.T";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 4, 1);
+  G g(vec.data(), 5, 4, 1);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge4) {
   std::string s = "AC.TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 4, 1);
+  G g(vec.data(), 5, 4, 1);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge5) {
   std::string s = "ACGTGT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 6);
+  G g(vec.data(), 6);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge6) {
   std::string s = "ACG.GT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 3, 1);
+  G g(vec.data(), 5, 3, 1);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge7) {
   std::string s = "ACG.TGT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 3, 1);
+  G g(vec.data(), 5, 3, 1);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge8) {
   std::string s = "AC..TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 2, 2);
+  G g(vec.data(), 5, 2, 2);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge9) {
   std::string s = "GAC..TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 6, 3, 2);
+  G g(vec.data(), 6, 3, 2);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge10) {
   std::string s = "GAC..TC";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 3, 2);
+  G g(vec.data(), 5, 3, 2);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge11) {
   std::string s = "GACTC";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 0, 0);
+  G g(vec.data(), 5, 0, 0);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge12) {
   std::string s = "AC.TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<true, 5> G;
-  G g(s.c_str(), 5, 2, 1);
+  G g(vec.data(), 5, 2, 1);
   bool res = sf::compare_generation<G, true, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge13) {
   std::string s = "A...CTCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 1, 3);
+  G g(vec.data(), 5, 1, 3);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge14) {
   std::string s = "AG.TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 2, 1);
+  G g(vec.data(), 5, 2, 1);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge15) {
   std::string s = "AGTC...T";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 4, 3);
+  G g(vec.data(), 5, 4, 3);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, Huddinge16) {
   std::string s = "AG...TCT";
+  auto vec = vec_from_string(s); 
   typedef gapmer<false, 5> G;
-  G g(s.c_str(), 5, 2, 3);
+  G g(vec.data(), 5, 2, 3);
   bool res = sf::compare_generation<G, false, 5>(g);
   ASSERT_TRUE(res);
 }
 
 TEST(gapmer, IsCanonical1) {
   std::string s = "AAAA...TTT";
+  auto vec = vec_from_string(s); 
   // rc = AAA...TTTT so technically smaller but ignore gap
-  gapmer<true, 5> g(s.c_str(), 7, 4, 3);
+  gapmer<true, 5> g(vec.data(), 7, 4, 3);
   ASSERT_TRUE(g.is_canonical());
 }
 
 TEST(gapmer, IsCanonical2) {
   std::string s = "ACGCCGT";
-  gapmer<true, 5> g(s.c_str(), 7);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 7);
   ASSERT_TRUE(g.is_canonical());
 }
 
 TEST(gapmer, IsCanonical3) {
   std::string s = "ACGGCGT";
-  gapmer<true, 5> g(s.c_str(), 7);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 7);
   ASSERT_FALSE(g.is_canonical());
 }
 
 TEST(gapmer, IsCanonical4) {
   std::string s = "AAATTT";
-  gapmer<true, 5> g(s.c_str(), 6);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 6);
   ASSERT_TRUE(g.is_canonical());
 }
 
 TEST(gapmer, IsCanonical5) {
   std::string s = "GGGTTT";
-  gapmer<true, 5> g(s.c_str(), 6);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 6);
   ASSERT_FALSE(g.is_canonical());
 }
 
 TEST(gapmer, RevComp1) {
   std::string s = "AAAATTTT";
-  gapmer<true, 5> g(s.c_str(), 8);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 8);
   g = g.reverse_complement();
   ASSERT_EQ(g.to_string(), s);
 }
@@ -415,7 +493,8 @@ TEST(gapmer, RevComp1) {
 TEST(gapmer, RevComp2) {
   std::string s = "AAA.TTTT";
   std::string rc = "AAAA.TTT";
-  gapmer<true, 5> g(s.c_str(), 7, 3, 1);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 7, 3, 1);
   g = g.reverse_complement();
   ASSERT_EQ(g.to_string(), rc);
 }
@@ -423,21 +502,24 @@ TEST(gapmer, RevComp2) {
 TEST(gapmer, RevComp3) {
   std::string s = "ACGTA";
   std::string rc = "TACGT";
-  gapmer<true, 5> g(s.c_str(), 5);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 5);
   g = g.reverse_complement();
   ASSERT_EQ(g.to_string(), rc);
 }
 
 TEST(gapmer, RevComp4) {
   std::string s = "ACGT";
-  gapmer<true, 5> g(s.c_str(), 4);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 4);
   g = g.reverse_complement();
   ASSERT_EQ(g.to_string(), s);
 }
 
 TEST(gapmer, Align1) {
   std::string s = "AAAAA";
-  gapmer<true, 5> g(s.c_str(), 5);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 5);
   bool res = g.aligns_to(g);
   ASSERT_TRUE(res);
   gapmer<true, 5> o = g.reverse_complement();
@@ -447,9 +529,11 @@ TEST(gapmer, Align1) {
 
 TEST(gapmer, Align2) {
   std::string s = "AAAAA";
+  auto vec = vec_from_string(s); 
   std::string os = "GGGGAAAAAT";
-  gapmer<true, 5> g(s.c_str(), 5);
-  gapmer<true, 5> o(os.c_str(), 10);
+  gapmer<true, 5> g(vec.data(), 5);
+  vec = vec_from_string(os); 
+  gapmer<true, 5> o(vec.data(), 10);
   bool res = g.aligns_to(o);
   ASSERT_TRUE(res);
 }
@@ -457,8 +541,10 @@ TEST(gapmer, Align2) {
 TEST(gapmer, Align3) {
   std::string s = "AAAAA";
   std::string os = "GGGG...AAAAA";
-  gapmer<true, 5> g(s.c_str(), 5);
-  gapmer<true, 5> o(os.c_str(), 9, 4, 3);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 5);
+  vec = vec_from_string(os); 
+  gapmer<true, 5> o(vec.data(), 9, 4, 3);
   bool res = g.aligns_to(o);
   ASSERT_TRUE(res);
 }
@@ -466,8 +552,10 @@ TEST(gapmer, Align3) {
 TEST(gapmer, Align4) {
   std::string s = "AAA...AA";
   std::string os = "GAAA...AATTT";
-  gapmer<true, 5> g(s.c_str(), 5, 3, 3);
-  gapmer<true, 5> o(os.c_str(), 9, 4, 3);
+  auto vec = vec_from_string(s); 
+  gapmer<true, 5> g(vec.data(), 5, 3, 3);
+  vec = vec_from_string(os); 
+  gapmer<true, 5> o(vec.data(), 9, 4, 3);
   bool res = g.aligns_to(o);
   ASSERT_TRUE(res);
 }


### PR DESCRIPTION
Underlying buffer is `vector<uint64_t>`, so `char*` cast from the `buf.data()` will be word aligned.

A bit hacky but should work with minimal fuss?