### PR TITLE
Encapsulate FASTA/Q parsing, ignore reads with wildcards (for now)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,10 @@
 *.a
 *.lib
 
-# Jupyter
+# Jupyter and Python
 .ipynb_checkpoints/
 *.ipynb
+__pycache__
 
 # Gcov related
 *.gcda
@@ -46,15 +47,22 @@ target/
 *.csv
 *.fasta
 *.txt
+*.dSYM
 
 # Executables
 *.exe
 *.out
 *.app
+comp
 huddinge
 huddinge_deb
-comp
+motivating
 seed_finder
 seed_finder_deb
 test/test
 test/cover  
+
+# User-specific
+.clangd
+.DS_Store
+.zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "deps/args"]
 	path = deps/args
 	url = https://github.com/Taywee/args.git
+[submodule "deps/libbio"]
+	path = deps/libbio
+	url = https://github.com/tsnorri/libbio.git

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ GCOV ?= gcov
 CFLAGS = -std=c++23 -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -march=native -DMAX_GAP=$(MAX_GAP)
 
 PERF_FLAGS = -O3 -g -DNDEBUG -fopenmp
-#PERF_FLAGS = -O0 -g -DDEBUG
 TEST_PERF_FLAGS = -O0 -g -DDEBUG
 
 DEBUG_FLAGS = -g -DDEBUG
@@ -22,17 +21,30 @@ INCLUDE += -Iinclude -isystem deps/sdsl-lite/include -isystem deps/seqio/include
 
 LIBS += -lboost_iostreams -lz -lgsl -lgslcblas -lm
 
-HEADERS =	include/bits.hpp \
+HEADERS =	include/args.hpp \
+			include/bits.hpp \
+			include/configuration.hpp \
+			include/dot_writer.hpp \
 			include/fm_index.hpp \
 			include/gapmer.hpp \
 			include/gapmer_count.hpp \
+			include/libbio_reader_adapter.hpp \
+			include/pack_characters.hpp \
+			include/packed_character_iteration.hpp \
 			include/partial_count.hpp \
+			include/reader_adapter.hpp \
 			include/seed_clusterer.hpp \
 			include/seed_finder.hpp \
+			include/seqio_reader_adapter.hpp \
 			include/string_buffer.hpp \
 			include/util.hpp \
-			include/dot_writer.hpp \
 			include/version.hpp
+
+SEED_FINDER_OBJECTS = \
+			libbio_reader_adapter.o \
+			pack_characters.o \
+			seed_finder.o \
+			seqio_reader_adapter.o
 
 ARGS = deps/args/args.hxx
 SDSL_DIR = deps/sdsl-lite/lib
@@ -46,8 +58,11 @@ TEST_HPP =	test/bit_tests_arbitrary.hpp \
 			test/gapmer_arbitrary.hpp \
 			test/gapmer_count_tests.hpp \
 			test/gapmer_tests.hpp \
+			test/nucleotide.hpp \
+			test/pack_characters_arbitrary.hpp \
 			test/packed_character_iteration_arbitrary.hpp \
 			test/string_buffer_arbitrary.hpp \
+			test/test.hpp \
 			test/util_tests.hpp
 
 
@@ -61,8 +76,8 @@ motivating: motivating.cpp
 huddinge: huddinge.cpp include/util.hpp include/gapmer.hpp
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge
 
-seed_finder: seed_finder.o libbio_reader_adapter.o $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) seed_finder.o libbio_reader_adapter.o -o seed_finder deps/libbio/src/libbio.a $(LIBS)
+seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
+	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder deps/libbio/src/libbio.a $(LIBS)
 
 comp: comp.cpp include/util.hpp
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) comp.cpp -o comp
@@ -70,10 +85,11 @@ comp: comp.cpp include/util.hpp
 huddinge_deb: huddinge.cpp $(HEADERS)
 	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge_deb
 
-seed_finder_deb: seed_finder.cpp $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
-	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) seed_finder.cpp -o seed_finder_deb $(LIBS)
+seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
+	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder_deb $(LIBS)
 
 clean:
+	$(RM) $(SEED_FINDER_OBJECTS)
 	rm -f huddinge huddinge_deb seed_finder seed_finder_deb comp
 	rm -f test/test test/cover test/test.o test/cover.o
 	rm -f *.gcov test/*.gcda test/*.gcno index.info

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ TEST_HPP =	test/bit_tests_arbitrary.hpp \
 			test/gapmer_arbitrary.hpp \
 			test/gapmer_count_tests.hpp \
 			test/gapmer_tests.hpp \
-			test/iterate_packed_characters_arbitrary.hpp \
+			test/packed_character_iteration_arbitrary.hpp \
 			test/string_buffer_arbitrary.hpp \
 			test/util_tests.hpp
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 GCOV ?= gcov
 
-CFLAGS = -std=c++23 -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -march=native -DMAX_GAP=$(MAX_GAP)
+CFLAGS = -std=c++23 -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -march=native -DMAX_GAP=$(MAX_GAP)
 
 PERF_FLAGS = -Ofast -g -DNDEBUG -fopenmp
 #PERF_FLAGS = -O0 -g -DDEBUG

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,55 @@ ifndef MAX_GAP
 MAX_GAP = 15
 endif
 
+CMAKE ?= cmake
 GCOV ?= gcov
 
-WARNING_FLAGS = -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -Wno-error=unused-command-line-argument
-CFLAGS = -std=c++23 $(WARNING_FLAGS) -march=native -DMAX_GAP=$(MAX_GAP)
+## Not used directly
+WARNING_FLAGS = \
+	-Wall \
+	-Werror \
+	-Wextra \
+	-Wshadow \
+	-Wno-gnu-conditional-omitted-operand \
+	-Wno-unused-parameter \
+	-Wno-unused-function \
+	-Wno-error=unused-command-line-argument
 
-PERF_FLAGS = -O3 -g -DNDEBUG -fopenmp
-TEST_PERF_FLAGS = -O0 -g -DDEBUG
-TEST_COVERAGE_PERF_FLAGS = -O1 -g --coverage
+PERF_FLAGS = -O3 -g -DNDEBUG -fopenmp -march=native
+DEBUG_PERF_FLAGS = -O0 -g -DDEBUG
+TEST_PERF_FLAGS = $(DEBUG_PERF_FLAGS)
+TEST_COVERAGE_PERF_FLAGS = -O1 -g
 
-DEBUG_FLAGS = -g -DDEBUG
+DEBUG_FLAGS = -DDEBUG
 
 ifdef VERBOSE
 DEBUG_FLAGS += -DVERBOSE
 endif
 
-INCLUDE += -Iinclude -isystem deps/sdsl-lite/include -isystem deps/seqio/include -isystem deps/args -isystem deps/libbio/include -isystem deps/libbio/lib/range-v3/include
+INCLUDE += \
+	-Iinclude \
+	-isystem deps/sdsl-lite/include \
+	-isystem deps/seqio/include \
+	-isystem deps/args \
+	-isystem deps/libbio/include \
+	-isystem deps/libbio/lib/range-v3/include
 
 LIBS += -lboost_iostreams -lz -lgsl -lgslcblas -lm
+
+## Used directly
+CPPFLAGS				= -DMAX_GAP=$(MAX_GAP) $(INCLUDE)
+CXXFLAGS				= -std=c++23 $(WARNING_FLAGS) $(PERF_FLAGS)
+LDFLAGS					= $(LIBS)
+DEBUG_CPPFLAGS			= $(CPPFLAGS) $(DEBUG_FLAGS)
+DEBUG_CXXFLAGS			= -std=c++23 $(WARNING_FLAGS) $(DEBUG_PERF_FLAGS)
+DEBUG_LDFLAGS			= $(LDFLAGS)
+TEST_CPPFLAGS			= -DGTEST_ON $(INCLUDE) -isystem $(GTEST_DIR)/googletest/include -isystem $(RAPIDCHECK_DIR)/include -isystem $(RAPIDCHECK_DIR)/extras/gtest/include
+TEST_CXXFLAGS			= -std=c++23 -pthread $(WARNING_FLAGS) $(TEST_PERF_FLAGS)
+TEST_LDFLAGS			= -L $(GTEST_DIR)/build/lib -L $(RAPIDCHECK_DIR)/build -lgtest_main -lgtest -lrapidcheck $(LIBS)
+TEST_COVERAGE_CPPFLAGS	= $(TEST_CPPFLAGS)
+TEST_COVERAGE_CXXFLAGS	= -std=c++23 -pthread --coverage $(WARNING_FLAGS) $(TEST_COVERAGE_PERF_FLAGS)
+TEST_COVERAGE_LDFLAGS	= $(TEST_LDFLAGS)
+
 
 HEADERS =	include/args.hpp \
 			include/bits.hpp \
@@ -48,6 +79,8 @@ SEED_FINDER_OBJECTS = \
 			seed_finder.o \
 			seqio_reader_adapter.o
 
+SEED_FINDER_DEBUG_OBJECTS = $(SEED_FINDER_OBJECTS:.o=.debug.o)
+
 TEST_OBJECTS = \
 			pack_characters.o \
 			test/test.o
@@ -56,17 +89,15 @@ TEST_COVERAGE_OBJECTS = $(TEST_OBJECTS:.o=.coverage.o)
 GCDA = $(TEST_COVERAGE_OBJECTS:.o=.gcda)
 GCNO = $(TEST_COVERAGE_OBJECTS:.o=.gcno)
 
-ARGS = deps/args/args.hxx
+ARGS_HXX = deps/args/args.hxx
 LIBBIO_DIR = deps/libbio
 SDSL_DIR = deps/sdsl-lite/lib
 
 GTEST_DIR = deps/googletest
 RAPIDCHECK_DIR = deps/rapidcheck
 
-TEST_CPPFLAGS = -DGTEST_ON -isystem $(GTEST_DIR)/googletest/include -isystem $(RAPIDCHECK_DIR)/include -isystem $(RAPIDCHECK_DIR)/extras/gtest/include
-TEST_LDFLAGS = -pthread -L $(GTEST_DIR)/build/lib -L $(RAPIDCHECK_DIR)/build
-
-TEST_HPP =	test/bit_tests_arbitrary.hpp \
+TEST_HEADERS = \
+			test/bit_tests_arbitrary.hpp \
 			test/gapmer_arbitrary.hpp \
 			test/gapmer_count_tests.hpp \
 			test/gapmer_tests.hpp \
@@ -78,34 +109,37 @@ TEST_HPP =	test/bit_tests_arbitrary.hpp \
 			test/util_tests.hpp
 
 
-.PHONY: clean all test cover
+.PHONY: clean all debug test cover
 
-%/%.hpp:
 
-motivating: motivating.cpp
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) -isystem deps/seqio/include motivating.cpp -o motivating
+all: motivating huddinge seed_finder comp
 
-huddinge: huddinge.cpp include/util.hpp include/gapmer.hpp
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge
+debug: seed_finder_deb huddinge_deb
 
-seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder $(LIBS)
+motivating: motivating.o
+	$(CXX) $(CXXFLAGS) $< -o $@ $(LDFLAGS)
 
-comp: comp.cpp include/util.hpp
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) comp.cpp -o comp
+huddinge: huddinge.o include/util.hpp include/gapmer.hpp
+	$(CXX) $(CXXFLAGS) $< -o $@ $(LDFLAGS)
 
-huddinge_deb: huddinge.cpp $(HEADERS)
-	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge_deb
+seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS_HXX) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
+	$(CXX) $(CXXFLAGS) $(SEED_FINDER_OBJECTS) -o $@ $(LDFLAGS)
 
-seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
-	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder_deb $(LIBS)
+comp: comp.o include/util.hpp
+	$(CXX) $(CXXFLAGS) $< -o $@ $(LDFLAGS)
+
+huddinge_deb: huddinge.debug.o $(HEADERS)
+	$(CXX) $(DEBUG_CXXFLAGS) $< -o $@ $(DEBUG_LDFLAGS)
+
+seed_finder_deb: $(SEED_FINDER_DEBUG_OBJECTS) $(HEADERS) $(ARGS_HXX) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
+	$(CXX) $(DEBUG_CXXFLAGS) $(SEED_FINDER_DEBUG_OBJECTS) -o $@ $(DEBUG_LDFLAGS)
 
 clean:
-	$(RM) $(SEED_FINDER_OBJECTS) $(TEST_OBJECTS) $(TEST_COVERAGE_OBJECTS)
+	$(RM) $(SEED_FINDER_OBJECTS) motivating.o huddinge.o comp.o $(SEED_FINDER_DEBUG_OBJECTS) huddinge.debug.o $(TEST_OBJECTS) $(TEST_COVERAGE_OBJECTS)
 	$(RM) $(GCDA) $(GCNO) coverage.info
-	rm -f huddinge huddinge_deb seed_finder seed_finder_deb comp
-	rm -f test/test test/cover
-	rm -rf target/
+	$(RM) huddinge huddinge_deb seed_finder seed_finder_deb comp motivating
+	$(RM) test/test test/cover
+	$(RM) -r target/
 
 $(SDSL_DIR):
 	git submodule update --init
@@ -116,7 +150,7 @@ $(GTEST_DIR)/googletest:
 $(RAPIDCHECK_DIR):
 	git submodule update --init
 
-$(ARGS):
+$(ARGS_HXX):
 	git submodule update --init
 
 $(LIBBIO_DIR):
@@ -132,38 +166,43 @@ local.mk:
 	bash -c "[ -e local.mk ] || echo -n "" > local.mk"
 
 $(GTEST_DIR)/build/lib/libgtest_main.a: | $(GTEST_DIR)/googletest
-	(mkdir -p $(GTEST_DIR)/build && cd $(GTEST_DIR)/build && cmake -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DBUILD_SHARED_LIBS=OFF .. && $(MAKE))
+	(mkdir -p $(GTEST_DIR)/build && cd $(GTEST_DIR)/build && $(CMAKE) -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DBUILD_SHARED_LIBS=OFF .. && $(MAKE))
 
 $(RAPIDCHECK_DIR)/build/librapidcheck.a: | $(RAPIDCHECK_DIR)
-	(mkdir -p $(RAPIDCHECK_DIR)/build && cd $(RAPIDCHECK_DIR)/build && cmake -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DBUILD_SHARED_LIBS=OFF -DRC_ENABLE_GTEST=ON .. && $(MAKE))
+	(mkdir -p $(RAPIDCHECK_DIR)/build && cd $(RAPIDCHECK_DIR)/build && $(CMAKE) -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DBUILD_SHARED_LIBS=OFF -DRC_ENABLE_GTEST=ON .. && $(MAKE))
+
+test/test: $(TEST_OBJECTS) $(HEADERS) $(TEST_HEADERS) $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a
+	$(CXX) $(TEST_CXXFLAGS) $(TEST_OBJECTS) -o $@ $(TEST_LDFLAGS)
+
+test/cover: $(TEST_COVERAGE_OBJECTS) $(HEADERS) $(TEST_HEADERS) $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a
+	$(CXX) $(TEST_COVERAGE_CXXFLAGS) $(TEST_COVERAGE_OBJECTS) -o $@ $(TEST_COVERAGE_LDFLAGS)
 
 test: test/test
 	test/test $(ARG)
 
-test/test: $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a $(HEADERS) $(TEST_HPP) $(TEST_OBJECTS)
-	$(CXX) $(CFLAGS) $(INCLUDE) $(TEST_PERF_FLAGS) $(TEST_OBJECTS) -o test/test $(TEST_LDFLAGS) -lgtest_main -lgtest -lrapidcheck $(LIBS)
-
-test/cover: $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a $(HEADERS) $(TEST_HPP) $(TEST_COVERAGE_OBJECTS)
-	$(CXX) $(CFLAGS) $(INCLUDE) $(TEST_COVERAGE_PERF_FLAGS) $(TEST_COVERAGE_OBJECTS) -o test/cover $(TEST_LDFLAGS) -lgtest_main -lgtest -lrapidcheck -lgcov $(LIBS)
-
 cover: test/cover
 	$(RM) $(GCDA) $(GCNO) coverage.info
-	test/cover
+	./test/cover
 	lcov -c --ignore-errors inconsistent,unused --directory test --output-file coverage.info --gcov-tool $(GCOV)
 	lcov --remove coverage.info "/usr*" --output-file coverage.info
 	genhtml coverage.info -o target
 
-test/test.o: $(TEST_HPP) $(GTEST_HEADERS) $(HEADERS) test/test.cpp
-	$(CXX) $(CFLAGS) $(TEST_CPPFLAGS) $(TEST_PERF_FLAGS) $(INCLUDE) -c test/test.cpp -o test/test.o
+test/test.o: test/test.cpp $(HEADERS) $(TEST_HEADERS) $(GTEST_HEADERS)
+	$(CXX) $(TEST_CPPFLAGS) $(TEST_CXXFLAGS) -c $< -o $@
 
-test/test.coverage.o: $(TEST_HPP) $(GTEST_HEADERS) $(HEADERS) test/test.cpp
-	$(CXX) $(CFLAGS) $(TEST_CPPFLAGS) $(TEST_COVERAGE_PERF_FLAGS) $(INCLUDE) -c test/test.cpp -o test/test.coverage.o
+test/test.coverage.o: test/test.cpp $(HEADERS) $(TEST_HEADERS) $(GTEST_HEADERS)
+	$(CXX) $(TEST_COVERAGE_CPPFLAGS) $(TEST_COVERAGE_CXXFLAGS) -c $< -o $@
+
+%/%.hpp:
 
 %.o: %.cpp
-	$(CXX) -c -o $@ $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $<
+	$(CXX) -c -o $@ $(CPPFLAGS) $(CXXFLAGS) $<
+
+%.debug.o: %.cpp
+	$(CXX) -c -o $@ $(DEBUG_CPPFLAGS) $(DEBUG_CXXFLAGS) $<
 
 %.coverage.o: %.cpp
-	$(CXX) -c -o $@ $(CFLAGS) $(TEST_COVERAGE_PERF_FLAGS) $(INCLUDE) $<
+	$(CXX) -c -o $@ $(TEST_COVERAGE_CPPFLAGS) $(TEST_COVERAGE_CXXFLAGS) $<
 
 # Output git tag or version hash to config.h.
 include/version.hpp: SHELL := /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ INCLUDE += \
 	-isystem deps/libbio/include \
 	-isystem deps/libbio/lib/range-v3/include
 
-LIBS += -lboost_iostreams -lz -lgsl -lgslcblas -lm
+LIBS += -lz -lgsl -lgslcblas -lm
 
 ## Used directly
 CPPFLAGS				= -DMAX_GAP=$(MAX_GAP) $(INCLUDE)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ HEADERS =	include/args.hpp \
 
 # FIXME: A library-based design could be a good idea.
 SEED_FINDER_OBJECTS = \
-			libbio_reader_adapter.o \
 			pack_characters.o \
 			seed_finder.o \
 			seqio_reader_adapter.o
@@ -89,8 +88,8 @@ motivating: motivating.cpp
 huddinge: huddinge.cpp include/util.hpp include/gapmer.hpp
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge
 
-seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
-	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder deps/libbio/src/libbio.a $(LIBS)
+seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
+	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder $(LIBS)
 
 comp: comp.cpp include/util.hpp
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) comp.cpp -o comp
@@ -98,7 +97,7 @@ comp: comp.cpp include/util.hpp
 huddinge_deb: huddinge.cpp $(HEADERS)
 	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge_deb
 
-seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
+seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
 	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder_deb $(LIBS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ endif
 
 GCOV ?= gcov
 
-CFLAGS = -std=c++23 -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -march=native -DMAX_GAP=$(MAX_GAP)
+WARNING_FLAGS = -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -Wno-error=unused-command-line-argument
+CFLAGS = -std=c++23 $(WARNING_FLAGS) -march=native -DMAX_GAP=$(MAX_GAP)
 
 PERF_FLAGS = -O3 -g -DNDEBUG -fopenmp
 TEST_PERF_FLAGS = -O0 -g -DDEBUG
+TEST_COVERAGE_PERF_FLAGS = -O1 -g --coverage
 
 DEBUG_FLAGS = -g -DDEBUG
 
@@ -40,19 +42,30 @@ HEADERS =	include/args.hpp \
 			include/util.hpp \
 			include/version.hpp
 
+# FIXME: A library-based design could be a good idea.
 SEED_FINDER_OBJECTS = \
 			libbio_reader_adapter.o \
 			pack_characters.o \
 			seed_finder.o \
 			seqio_reader_adapter.o
 
+TEST_OBJECTS = \
+			pack_characters.o \
+			test/test.o
+
+TEST_COVERAGE_OBJECTS = $(TEST_OBJECTS:.o=.coverage.o)
+GCDA = $(TEST_COVERAGE_OBJECTS:.o=.gcda)
+GCNO = $(TEST_COVERAGE_OBJECTS:.o=.gcno)
+
 ARGS = deps/args/args.hxx
+LIBBIO_DIR = deps/libbio
 SDSL_DIR = deps/sdsl-lite/lib
 
 GTEST_DIR = deps/googletest
 RAPIDCHECK_DIR = deps/rapidcheck
 
-GFLAGS = -lpthread -DGTEST_ON -isystem $(GTEST_DIR)/googletest/include -isystem $(RAPIDCHECK_DIR)/include -isystem $(RAPIDCHECK_DIR)/extras/gtest/include -pthread -L $(GTEST_DIR)/build/lib -L $(RAPIDCHECK_DIR)/build
+TEST_CPPFLAGS = -DGTEST_ON -isystem $(GTEST_DIR)/googletest/include -isystem $(RAPIDCHECK_DIR)/include -isystem $(RAPIDCHECK_DIR)/extras/gtest/include
+TEST_LDFLAGS = -pthread -L $(GTEST_DIR)/build/lib -L $(RAPIDCHECK_DIR)/build
 
 TEST_HPP =	test/bit_tests_arbitrary.hpp \
 			test/gapmer_arbitrary.hpp \
@@ -76,7 +89,7 @@ motivating: motivating.cpp
 huddinge: huddinge.cpp include/util.hpp include/gapmer.hpp
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge
 
-seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
+seed_finder: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
 	$(CXX) $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder deps/libbio/src/libbio.a $(LIBS)
 
 comp: comp.cpp include/util.hpp
@@ -85,14 +98,14 @@ comp: comp.cpp include/util.hpp
 huddinge_deb: huddinge.cpp $(HEADERS)
 	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) huddinge.cpp -o huddinge_deb
 
-seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) deps/libbio
+seed_finder_deb: $(SEED_FINDER_OBJECTS) $(HEADERS) $(ARGS) deps/libbio/src/libbio.a | $(SDSL_DIR) $(ARGS_DIR) $(LIBBIO_DIR)
 	$(CXX) $(CFLAGS) $(DEBUG_FLAGS) $(INCLUDE) $(SEED_FINDER_OBJECTS) -o seed_finder_deb $(LIBS)
 
 clean:
-	$(RM) $(SEED_FINDER_OBJECTS)
+	$(RM) $(SEED_FINDER_OBJECTS) $(TEST_OBJECTS) $(TEST_COVERAGE_OBJECTS)
+	$(RM) $(GCDA) $(GCNO) coverage.info
 	rm -f huddinge huddinge_deb seed_finder seed_finder_deb comp
-	rm -f test/test test/cover test/test.o test/cover.o
-	rm -f *.gcov test/*.gcda test/*.gcno index.info
+	rm -f test/test test/cover
 	rm -rf target/
 
 $(SDSL_DIR):
@@ -107,13 +120,13 @@ $(RAPIDCHECK_DIR):
 $(ARGS):
 	git submodule update --init
 
-deps/libbio:
+$(LIBBIO_DIR):
 	git submodule update --init --recursive
 
-deps/libbio/src/libbio.a: deps/libbio/local.mk
+$(LIBBIO_DIR)/src/libbio.a: deps/libbio/local.mk
 	$(MAKE) -C deps/libbio src/libbio.a
 
-deps/libbio/local.mk: local.mk
+$(LIBBIO_DIR)/local.mk: local.mk
 	cp local.mk deps/libbio/
 
 local.mk:
@@ -125,27 +138,33 @@ $(GTEST_DIR)/build/lib/libgtest_main.a: | $(GTEST_DIR)/googletest
 $(RAPIDCHECK_DIR)/build/librapidcheck.a: | $(RAPIDCHECK_DIR)
 	(mkdir -p $(RAPIDCHECK_DIR)/build && cd $(RAPIDCHECK_DIR)/build && cmake -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DBUILD_SHARED_LIBS=OFF -DRC_ENABLE_GTEST=ON .. && $(MAKE))
 
-test/test.o: $(TEST_HPP) $(GTEST_HEADERS) $(HEADERS) test/test.cpp
-	$(CXX) $(CFLAGS) $(GFLAGS) -c test/test.cpp -o test/test.o
-
-test/test: $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a $(TEST_HPP) $(HEADERS) test/test.cpp
-	$(CXX) $(CFLAGS) $(GFLAGS) $(INCLUDE) $(TEST_PERF_FLAGS) test/test.cpp -o test/test -lgtest_main -lgtest -lrapidcheck $(LIBS)
-
 test: test/test
 	test/test $(ARG)
 
-test/cover: $(GTEST_DIR)/build/lib/libgtest_main.a $(TEST_HPP) $(HEADERS) test/test.cpp
-	$(CXX) -g --coverage -O1 $(CFLAGS) $(GFLAGS) $(INCLUDE) test/test.cpp -o test/cover -lgtest_main -lgtest -lrapidcheck -lgcov $(LIBS)
+test/test: $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a $(HEADERS) $(TEST_HPP) $(TEST_OBJECTS)
+	$(CXX) $(CFLAGS) $(INCLUDE) $(TEST_PERF_FLAGS) $(TEST_OBJECTS) -o test/test $(TEST_LDFLAGS) -lgtest_main -lgtest -lrapidcheck $(LIBS)
+
+test/cover: $(GTEST_DIR)/build/lib/libgtest_main.a $(RAPIDCHECK_DIR)/build/librapidcheck.a $(HEADERS) $(TEST_HPP) $(TEST_COVERAGE_OBJECTS)
+	$(CXX) $(CFLAGS) $(INCLUDE) $(TEST_COVERAGE_PERF_FLAGS) $(TEST_COVERAGE_OBJECTS) -o test/cover $(TEST_LDFLAGS) -lgtest_main -lgtest -lrapidcheck -lgcov $(LIBS)
 
 cover: test/cover
-	rm -f *.gcov test/*.gcda coverage.info
+	$(RM) $(GCDA) $(GCNO) coverage.info
 	test/cover
 	lcov -c --ignore-errors inconsistent,unused --directory test --output-file coverage.info --gcov-tool $(GCOV)
 	lcov --remove coverage.info "/usr*" --output-file coverage.info
 	genhtml coverage.info -o target
 
+test/test.o: $(TEST_HPP) $(GTEST_HEADERS) $(HEADERS) test/test.cpp
+	$(CXX) $(CFLAGS) $(TEST_CPPFLAGS) $(TEST_PERF_FLAGS) $(INCLUDE) -c test/test.cpp -o test/test.o
+
+test/test.coverage.o: $(TEST_HPP) $(GTEST_HEADERS) $(HEADERS) test/test.cpp
+	$(CXX) $(CFLAGS) $(TEST_CPPFLAGS) $(TEST_COVERAGE_PERF_FLAGS) $(INCLUDE) -c test/test.cpp -o test/test.coverage.o
+
 %.o: %.cpp
 	$(CXX) -c -o $@ $(CFLAGS) $(PERF_FLAGS) $(INCLUDE) $<
+
+%.coverage.o: %.cpp
+	$(CXX) -c -o $@ $(CFLAGS) $(TEST_COVERAGE_PERF_FLAGS) $(INCLUDE) $<
 
 # Output git tag or version hash to config.h.
 include/version.hpp: SHELL := /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GCOV ?= gcov
 
 CFLAGS = -std=c++23 -Wall -Werror -Wextra -Wshadow -Wno-gnu-conditional-omitted-operand -Wno-unused-parameter -Wno-unused-function -march=native -DMAX_GAP=$(MAX_GAP)
 
-PERF_FLAGS = -Ofast -g -DNDEBUG -fopenmp
+PERF_FLAGS = -O3 -g -DNDEBUG -fopenmp
 #PERF_FLAGS = -O0 -g -DDEBUG
 TEST_PERF_FLAGS = -O0 -g -DDEBUG
 
@@ -42,7 +42,14 @@ RAPIDCHECK_DIR = deps/rapidcheck
 
 GFLAGS = -lpthread -DGTEST_ON -isystem $(GTEST_DIR)/googletest/include -isystem $(RAPIDCHECK_DIR)/include -isystem $(RAPIDCHECK_DIR)/extras/gtest/include -pthread -L $(GTEST_DIR)/build/lib -L $(RAPIDCHECK_DIR)/build
 
-TEST_HPP = test/gapmer_tests.hpp test/util_tests.hpp test/gapmer_count_tests.hpp
+TEST_HPP =	test/bit_tests_arbitrary.hpp \
+			test/gapmer_arbitrary.hpp \
+			test/gapmer_count_tests.hpp \
+			test/gapmer_tests.hpp \
+			test/iterate_packed_characters_arbitrary.hpp \
+			test/string_buffer_arbitrary.hpp \
+			test/util_tests.hpp
+
 
 .PHONY: clean all test cover
 

--- a/include/configuration.hpp
+++ b/include/configuration.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+//#include "libbio_reader_adapter.hpp"
+#include "seqio_reader_adapter.hpp"
+
+namespace sf {
+typedef seqio_reader_adapter reader_adapter_type;
+}

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -227,6 +227,8 @@ template <bool middle_gap_only, uint16_t t_max_gap>
 uint64_t gapmer<middle_gap_only, t_max_gap>::from_packed_characters(
     std::span<uint64_t const> data, uint8_t kk, uint8_t gap_start,
     uint8_t gap_length) {
+  // We assume that the first two words of the span enclose the range
+  // of the packed characters including the gap.
   auto const tail_start{gap_start + gap_length};
   auto const tail_length{kk - gap_start};
   auto const tail_start_word_idx{tail_start / 32U};

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -120,7 +120,7 @@ class gapmer {
   /// bytes.
   gapmer(std::span<uint64_t const> data, uint8_t kk, uint8_t gap_start,
          uint8_t gap_length)
-      : gapmer(from_value(data, kk, gap_start, gap_length), kk, gap_start,
+      : gapmer(from_packed_characters(data, kk, gap_start, gap_length), kk, gap_start,
                gap_length) {}
 
   uint64_t data() const { return data_; }  //< Get the packed data.

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -54,14 +54,13 @@ class gapmer {
                                                       uint8_t gap_start = 0,
                                                       uint8_t gap_length = 0);
 
-  /// Takes packed characters as input, returns the packed representation
+  /// Takes data as input, returns the packed representation
   /// including the lengths and the gap position.
-  static inline uint64_t from_packed_characters(uint64_t data, uint8_t kk);
-  /// Takes packed characters as input, returns the packed representation
+  static inline uint64_t from_value(uint64_t data, uint8_t kk);
+  /// Takes data as input, returns the packed representation
   /// including the lengths and the gap position.
-  static inline uint64_t from_packed_characters(uint64_t data, uint8_t kk,
-                                                uint8_t gap_start,
-                                                uint8_t gap_length);
+  static inline uint64_t from_value(uint64_t data, uint8_t kk,
+                                    uint8_t gap_start, uint8_t gap_length);
   /// Takes packed characters as input, returns the packed representation
   /// including the lengths and the gap position.
   static inline uint64_t from_packed_characters(std::span<uint64_t const> data,
@@ -100,10 +99,10 @@ class gapmer {
  public:
   constexpr gapmer() = default;  //< Construct an empty value.
   /// Construct from the given packed data and lengths.
-  gapmer(uint64_t v, uint8_t k) : data_(from_packed_characters(v, k)) {}
+  gapmer(uint64_t v, uint8_t k) : data_(from_value(v, k)) {}
   /// Construct from the given packed data, gap position and lengths.
   gapmer(uint64_t v, uint8_t k, uint8_t gap_start, uint8_t gap_length)
-      : data_(from_packed_characters(v, k, gap_start, gap_length)) {}
+      : data_(from_value(v, k, gap_start, gap_length)) {}
 
   /// Construct from the given character data ([ACGT.]*) aligned to 8 bytes.
   gapmer(uint64_t const* d_ptr, uint8_t kk)
@@ -121,8 +120,8 @@ class gapmer {
   /// bytes.
   gapmer(std::span<uint64_t const> data, uint8_t kk, uint8_t gap_start,
          uint8_t gap_length)
-      : gapmer(from_packed_characters(data, kk, gap_start, gap_length), kk,
-               gap_start, gap_length) {}
+      : gapmer(from_value(data, kk, gap_start, gap_length), kk, gap_start,
+               gap_length) {}
 
   uint64_t data() const { return data_; }  //< Get the packed data.
   operator uint64_t() const { return data(); }  //< Get the packed data.
@@ -199,8 +198,8 @@ gapmer<middle_gap_only, t_max_gap>::gapmer(uint64_t prefix, uint64_t suffix,
 }
 
 template <bool middle_gap_only, uint16_t t_max_gap>
-uint64_t gapmer<middle_gap_only, t_max_gap>::from_packed_characters(
-    uint64_t data, uint8_t kk) {
+uint64_t gapmer<middle_gap_only, t_max_gap>::from_value(uint64_t data,
+                                                        uint8_t kk) {
   assert(kk <= max_k);
   uint64_t meta{kk};
   meta <<= 2 * max_k;
@@ -208,8 +207,10 @@ uint64_t gapmer<middle_gap_only, t_max_gap>::from_packed_characters(
 }
 
 template <bool middle_gap_only, uint16_t t_max_gap>
-uint64_t gapmer<middle_gap_only, t_max_gap>::from_packed_characters(
-    uint64_t data, uint8_t kk, uint8_t gap_start, uint8_t gap_length) {
+uint64_t gapmer<middle_gap_only, t_max_gap>::from_value(uint64_t data,
+                                                        uint8_t kk,
+                                                        uint8_t gap_start,
+                                                        uint8_t gap_length) {
   assert(kk <= max_k);
   assert((0 == gap_start && 0 == gap_length) ||
          (gap_start < kk && gap_length <= max_gap));

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -228,6 +228,14 @@ template <bool middle_gap_only, uint16_t t_max_gap>
 uint64_t gapmer<middle_gap_only, t_max_gap>::from_packed_characters(
     std::span<uint64_t const> data, uint8_t kk, uint8_t gap_start,
     uint8_t gap_length) {
+  [[unlikely]] if (data.empty())
+  {
+    assert(0 == kk);
+    assert(0 == gap_start);
+    assert(0 == gap_length);
+    return 0;
+  }
+
   // We assume that the first two words of the span enclose the range
   // of the packed characters including the gap.
   auto const tail_start{gap_start + gap_length};

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -54,22 +54,25 @@ class gapmer {
                                                       uint8_t gap_start = 0,
                                                       uint8_t gap_length = 0);
 
-  static inline uint64_t from_packed_characters(
-      uint64_t data,
-      uint8_t kk);  //< Returns the packed representation including the length.
-  static inline uint64_t from_packed_characters(
-      uint64_t data, uint8_t kk, uint8_t gap_start,
-      uint8_t gap_length);  //< Returns the packed representation including the
-                            // lengths and the gap position.
+  /// Takes packed characters as input, returns the packed representation
+  /// including the lengths and the gap position.
+  static inline uint64_t from_packed_characters(uint64_t data, uint8_t kk);
+  /// Takes packed characters as input, returns the packed representation
+  /// including the lengths and the gap position.
+  static inline uint64_t from_packed_characters(uint64_t data, uint8_t kk,
+                                                uint8_t gap_start,
+                                                uint8_t gap_length);
+  /// Takes packed characters as input, returns the packed representation
+  /// including the lengths and the gap position.
   static inline uint64_t from_packed_characters(std::span<uint64_t const> data,
                                                 uint8_t kk, uint8_t gap_start,
                                                 uint8_t gap_length);
 
-  explicit gapmer(uint64_t data)
-      : data_(data) {}  //< Construct from the given data.
+  /// Construct from the given data.
+  explicit gapmer(uint64_t data) : data_(data) {}
+  /// Construct from the given prefix, suffix, gap position and lengths.
   gapmer(uint64_t prefix, uint64_t suffix, uint8_t p_len, uint8_t s_len,
-         uint8_t gap_s, uint8_t gap_l);  //< Construct from the given prefix,
-                                         // suffix, gap position and lengths.
+         uint8_t gap_s, uint8_t gap_l);
 
   uint64_t prefix() const;
   uint64_t suffix() const;
@@ -77,8 +80,10 @@ class gapmer {
   uint64_t suffix(uint64_t i) const;
   gapmer hamming(uint64_t v, auto& callback) const;
 
- public:  // FIXME: all_gap_neighbours, middle_gap_neighbours should be private.
-          // For now they are public so that unit tests can access them.
+ public:
+  // FIXME: Consider making all_gap_neighbours, middle_gap_neighbours private.
+  // For now they are public so that unit tests can access them.
+
   template <bool no_smaller, bool no_same, bool no_larger>
   void middle_gap_neighbours(auto&& callback) const;
 
@@ -94,12 +99,11 @@ class gapmer {
 
  public:
   constexpr gapmer() = default;  //< Construct an empty value.
-  gapmer(uint64_t v, uint8_t k)
-      : data_(from_packed_characters(v, k)) {
-  }  //< Construct from the given packed data and lengths.
+  /// Construct from the given packed data and lengths.
+  gapmer(uint64_t v, uint8_t k) : data_(from_packed_characters(v, k)) {}
+  /// Construct from the given packed data, gap position and lengths.
   gapmer(uint64_t v, uint8_t k, uint8_t gap_start, uint8_t gap_length)
-      : data_(from_packed_characters(v, k, gap_start, gap_length)) {
-  }  //< Construct from the given packed data, gap position and lengths.
+      : data_(from_packed_characters(v, k, gap_start, gap_length)) {}
 
   /// Construct from the given character data ([ACGT.]*) aligned to 8 bytes.
   gapmer(uint64_t const* d_ptr, uint8_t kk)
@@ -122,12 +126,10 @@ class gapmer {
 
   uint64_t data() const { return data_; }  //< Get the packed data.
   operator uint64_t() const { return data(); }  //< Get the packed data.
-  bool operator==(const gapmer& rhs) const {
-    return data_ == rhs.data_;
-  }  //< Compare packed bytes.
-  bool operator!=(const gapmer& rhs) const {
-    return data_ != rhs.data_;
-  }  //< Compare packed bytes.
+  /// Compare packed bytes.
+  bool operator==(const gapmer& rhs) const { return data_ == rhs.data_; }
+  /// Compare packed bytes.
+  bool operator!=(const gapmer& rhs) const { return data_ != rhs.data_; }
 
   template <bool compare_rc = false, bool debug = false>
   bool is_neighbour(const gapmer& other) const;
@@ -146,29 +148,25 @@ class gapmer {
 
   size_t compute_offset(const gapmer& other, int& out) const;
 
-  uint16_t length() const {
-    return (data_ >> (max_k * 2)) & meta_mask;
-  }  //< Get the count of the defined bases.
+  /// Get the count of the defined bases.
+  uint16_t length() const { return (data_ >> (max_k * 2)) & meta_mask; }
   uint16_t gap_start() const;  //< Get the starting position of the gap.
-  uint16_t gap_length() const {
-    return data_ >> (max_k * 2 + 10);
-  }  //< Get the gap length.
-  uint8_t nuc(uint8_t i) const;  //< Get the i-th 2-bit encoded nucleotide (gap
-                                 // not taken into account).
-  uint8_t get_c(uint64_t i)
-      const;  //< Get the unpacked character or gap at the i-th position.
-  uint64_t value() const {
-    return data_ & value_mask;
-  }  //< Get the encoded value.
-  gapmer next(
-      char c) const;  //< For a non-gapped gapmer, returns a copy of it with c
-                      // appended and the leftmost character removed. If this is
-                      // empty, returns an empty gapmer.
+  /// Get the gap length.
+  uint16_t gap_length() const { return data_ >> (max_k * 2 + 10); }
+  /// Get the i-th 2-bit encoded nucleotide (gap not taken into account).
+  uint8_t nuc(uint8_t i) const;
+  /// Get the unpacked character or gap at the i-th position.
+  uint8_t get_c(uint64_t i) const;
+  /// Get the encoded value.
+  uint64_t value() const { return data_ & value_mask; }
+  /// For a non-gapped gapmer, returns a copy of it with c appended and the
+  /// leftmost character removed. If this is empty, returns an empty gapmer.
+  gapmer next(char c) const;
   gapmer next_(std::uint8_t c) const;
-  gapmer next(char c1, char c2)
-      const;  //< For a gapped gapmer, returns a copy of it with c1 and c2
-              // appended respectively to the prefix and to the suffix, with the
-              // leftmost characters removed.
+  /// For a gapped gapmer, returns a copy of it with c1 and c2 appended
+  /// respectively to the prefix and to the suffix, with the leftmost characters
+  /// removed.
+  gapmer next(char c1, char c2) const;
   gapmer next_(std::uint8_t c1, std::uint8_t c2) const;
   void hamming_neighbours(auto& callback) const;
 
@@ -176,12 +174,14 @@ class gapmer {
             bool no_larger = false>
   void huddinge_neighbours(auto&& callback) const;
 
-  uint16_t huddinge_distance(
-      gapmer const other, int& out) const;  //< Calculate the Huddinge distance.
-  std::string to_string() const;  //< Returns the sequence as std::string.
-  bool is_canonical()
-      const;  //< Returns true iff. this is lexicographically equal or smaller
-              // than its reverse complement. // FIXME: is the statement true?
+  /// Calculate the Huddinge distance.
+  uint16_t huddinge_distance(gapmer const other, int& out) const;
+  /// Returns the sequence as std::string.
+  std::string to_string() const;
+  /// Returns true iff. this is lexicographically equal or smaller
+  /// than its reverse complement.
+  // FIXME: is the statement true?
+  bool is_canonical() const;
   gapmer reverse_complement() const;  //< Get this’s reverse complement.
   bool is_valid() const;
   std::bitset<64> bits() const { return data_; }
@@ -258,14 +258,14 @@ uint64_t gapmer<middle_gap_only, t_max_gap>::read_word_aligned_characters(
     uint64_t const* d_ptr, uint8_t const kk, uint8_t const gap_start,
     uint8_t const gap_length) {
   assert(kk <= max_k);
-  assert(gap_start < kk); // The gap needs to start before the end of the text.
+  assert(gap_start < kk);  // The gap needs to start before the end of the text.
   assert(gap_length <= max_gap);
 
   uint64_t retval{};
   uint8_t ii{};
-  uint8_t const limit((kk + gap_length + 7) /
-                      8);  // Since d_ptr is uint64_t const *, we are bound to
-                           // have a multiple of 8 bytes.
+  // Since d_ptr is uint64_t const *, we are bound to
+  // have a multiple of 8 bytes.
+  uint8_t const limit((kk + gap_length + 7) / 8);
   if constexpr (t_has_gap) {
     assert(gap_start);
     assert(gap_length);
@@ -390,9 +390,9 @@ void gapmer<middle_gap_only, t_max_gap>::middle_gap_neighbours(
     auto&& callback) const {
   const uint64_t val = value();
   const uint8_t len = length();
-  assert(no_larger ||
-         len < max_k);  // It is the user’s responsibility to check the length
-                        // before listing the neighbours.
+  // It is the user’s responsibility to check the length before listing the
+  // neighbours.
+  assert(no_larger || len < max_k);
   assert(no_smaller || 5 <= len);
   const uint8_t gap_s = gap_start();
   const uint8_t prefix_len = gap_s;

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -8,6 +8,7 @@
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <span>
 #include <string>
 
@@ -17,7 +18,6 @@
 #ifdef DEBUG
 #include <bitset>
 #include <cassert>
-#include <iostream>
 #endif
 
 namespace sf {
@@ -153,10 +153,12 @@ class gapmer {
       char c) const;  //< For a non-gapped gapmer, returns a copy of it with c
                       // appended and the leftmost character removed. If this is
                       // empty, returns an empty gapmer.
+  gapmer next_(std::uint8_t c) const;
   gapmer next(char c1, char c2)
       const;  //< For a gapped gapmer, returns a copy of it with c1 and c2
               // appended respectively to the prefix and to the suffix, with the
               // leftmost characters removed.
+  gapmer next_(std::uint8_t c1, std::uint8_t c2) const;
   void hamming_neighbours(auto& callback) const;
 
   template <bool no_smaller = false, bool no_same = false,
@@ -1354,17 +1356,28 @@ uint8_t gapmer<middle_gap_only, t_max_gap>::get_c(uint64_t i) const {
 
 template <bool middle_gap_only, uint16_t t_max_gap>
 auto gapmer<middle_gap_only, t_max_gap>::next(char c) const -> gapmer {
+  return next_(nuc_to_v[c]);
+}
+
+template <bool middle_gap_only, uint16_t t_max_gap>
+auto gapmer<middle_gap_only, t_max_gap>::next_(std::uint8_t c) const -> gapmer {
 #ifdef DEBUG
   assert(gap_length() == 0);
 #endif
   uint64_t v = data_ << 2;
-  v |= nuc_to_v[c];
+  v |= c;
   v &= (ONE << (length() * 2)) - 1;
   return gapmer{(data_ & ~value_mask) | v};
 }
 
 template <bool middle_gap_only, uint16_t t_max_gap>
 auto gapmer<middle_gap_only, t_max_gap>::next(char c1, char c2) const
+    -> gapmer {
+  return next_(nuc_to_v[c1], nuc_to_v[c2]);
+}
+
+template <bool middle_gap_only, uint16_t t_max_gap>
+auto gapmer<middle_gap_only, t_max_gap>::next_(std::uint8_t c1, std::uint8_t c2) const
     -> gapmer {
 #ifdef DEBUG
   assert(gap_length() > 0);

--- a/include/gapmer.hpp
+++ b/include/gapmer.hpp
@@ -21,11 +21,12 @@
 #endif
 
 namespace sf {
-template <bool middle_gap_only = false, uint16_t t_max_gap = 10>
+template <bool t_middle_gap_only = false, uint16_t t_max_gap = 10>
 class gapmer {
  public:
-  const static constexpr uint64_t max_k = 24;
-  const static constexpr uint16_t max_gap = t_max_gap;
+  const static constexpr uint64_t max_k{24};
+  const static constexpr uint16_t max_gap{t_max_gap};
+  const static constexpr bool middle_gap_only{t_middle_gap_only};
 
  private:
   const static constexpr uint64_t ONE = 1;
@@ -1385,8 +1386,8 @@ auto gapmer<middle_gap_only, t_max_gap>::next_(std::uint8_t c1, std::uint8_t c2)
   uint64_t suf_len = (length() - gap_start()) * 2;
   uint64_t gap_mask = uint64_t(0b11) << suf_len;
   uint64_t v = (data_ << 2) & ~gap_mask;
-  v |= uint64_t(nuc_to_v[c1]) << suf_len;
-  v |= nuc_to_v[c2];
+  v |= uint64_t{c1} << suf_len;
+  v |= c2;
   v &= (ONE << (length() * 2)) - 1;
   return gapmer{(data_ & ~value_mask) | v};
 }

--- a/include/gapmer_count.hpp
+++ b/include/gapmer_count.hpp
@@ -73,7 +73,7 @@ class gapmer_count {
         continue;
 
       auto const &read_buffer{reader_adapter.read_buffer()};
-      gapmer<middle_gap_only, max_gap> g(read_buffer.front() >> (64U - 2U * k), k); // FIXME: replace 48 with 2 * gapmer_type::max_gap.
+      gapmer<middle_gap_only, max_gap> g(read_buffer.front() >> (64U - 2U * k), k);
       uint64_t cv = g.value();
 #pragma omp atomic
       counts[cv] = counts[cv] + 1;

--- a/include/gapmer_count.hpp
+++ b/include/gapmer_count.hpp
@@ -13,8 +13,9 @@
 #include <string_view>
 #include <utility>
 
+#include "configuration.hpp"
 #include "gapmer.hpp"
-#include "libbio_reader_adapter.hpp"
+#include "reader_adapter.hpp"
 
 namespace sf {
 
@@ -51,7 +52,7 @@ class gapmer_count {
     return ret;
   }
 
-  libbio_reader_adapter reader_adapter;
+  reader_adapter_type reader_adapter;
   double* sig_counts;
   double* bg_counts;
   sdsl::bit_vector discarded;
@@ -111,7 +112,7 @@ class gapmer_count {
  public:
   gapmer_count(const std::string& sig_fasta_path,
                const std::string& bg_fasta_path, uint8_t k,
-               libbio_reader_adapter_delegate &delegate)
+               reader_adapter_delegate &delegate)
       : reader_adapter(delegate),
         sig_counts((double*)calloc(lookup_elems(k), sizeof(double))),
         bg_counts((double*)calloc(lookup_elems(k), sizeof(double))),

--- a/include/libbio_reader_adapter.hpp
+++ b/include/libbio_reader_adapter.hpp
@@ -12,48 +12,23 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <vector>
-#include "packed_character_iteration.hpp"
+#include "reader_adapter.hpp"
 
 
 namespace sf {
 
-	std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos);
-	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst);
-
-
-	class libbio_reader_adapter;
-
-
-	struct libbio_reader_adapter_delegate
+	class libbio_reader_adapter final : public reader_adapter, public libbio::fasta_reader_delegate, libbio::fastq_reader_delegate
 	{
-		virtual ~libbio_reader_adapter_delegate() {}
-		virtual bool should_report_errors_for_path(libbio_reader_adapter &adapter, std::string_view path) = 0;
-		virtual void found_first_read_with_unexpected_character(libbio_reader_adapter &adapter, std::string_view path, std::uint64_t lineno) = 0;
-		virtual void found_total_reads_with_unexpected_characters(libbio_reader_adapter &adapter, std::string_view path, std::uint64_t count) = 0;
-	};
-
-
-	class libbio_reader_adapter final : public libbio::fasta_reader_delegate, libbio::fastq_reader_delegate
-	{
-	public:
-		typedef packed_word_vector read_buffer_type;
-		typedef libbio_reader_adapter_delegate delegate_type;
-
 	private:
 		libbio::fasta_reader		m_fasta_reader;
 		libbio::fastq_reader		m_fastq_reader;
 
 		libbio::file_handle			m_handle;
 		libbio::gzip_reading_handle	m_gzip_handle;
-		std::string					m_current_input_path;
-
-		read_buffer_type			m_read_buffer;
-		std::uint64_t				m_read_length{};
+		std::string					m_input_path;
 
 		libbio::sequence_reader		*m_reader{};
 		libbio::reading_handle		*m_reading_handle{};
-		delegate_type				*m_delegate{};
 
 		std::size_t					m_parsing_block_size{};
 		std::uint64_t				m_skipped_reads{};
@@ -64,8 +39,8 @@ namespace sf {
 	public:
 		constexpr libbio_reader_adapter() = default;
 
-		explicit libbio_reader_adapter(libbio_reader_adapter_delegate &delegate):
-			m_delegate(&delegate)
+		explicit libbio_reader_adapter(reader_adapter_delegate &delegate):
+			reader_adapter(delegate)
 		{
 			m_fasta_reader.set_delegate(*this);
 			m_fastq_reader.set_delegate(*this);
@@ -78,19 +53,11 @@ namespace sf {
 		libbio_reader_adapter &operator=(libbio_reader_adapter const &) = delete;
 		libbio_reader_adapter &operator=(libbio_reader_adapter &&) & = default;
 
-		void read_from_path(std::string const &path) { read_from_path(path.c_str()); }
-		void read_from_path(char const *path);
-		bool retrieve_next_read();
-		void finish();
+		using reader_adapter::read_from_path;
 
-		std::uint64_t read_length() const { return m_read_length; }
-		read_buffer_type const &read_buffer() const { return m_read_buffer; }
-
-		template <typename t_cb>
-		void iterate_characters(std::uint64_t start_pos, t_cb &&cb) const { iterate_packed_characters(m_read_buffer, m_read_length, start_pos, cb); }
-
-		template <typename t_cb>
-		void iterate_character_pairs(std::uint64_t lhs_start, std::uint64_t rhs_start, t_cb &&cb) const { iterate_packed_character_pairs(m_read_buffer, m_read_length, lhs_start, rhs_start, cb); }
+		void read_from_path(char const *path) override;
+		bool retrieve_next_read() override;
+		void finish() override;
 
 	private:
 		bool handle_identifier(libbio::fasta_reader_base &, std::string_view, std::span <std::string_view const>) override { return true; }

--- a/include/libbio_reader_adapter.hpp
+++ b/include/libbio_reader_adapter.hpp
@@ -12,62 +12,80 @@
 #include <span>
 #include <string>
 #include <string_view>
+
 #include "reader_adapter.hpp"
 
 
 namespace sf {
 
-	class libbio_reader_adapter final : public reader_adapter, public libbio::fasta_reader_delegate, libbio::fastq_reader_delegate
-	{
-	private:
-		libbio::fasta_reader		m_fasta_reader;
-		libbio::fastq_reader		m_fastq_reader;
+class libbio_reader_adapter final : public reader_adapter,
+                                    public libbio::fasta_reader_delegate,
+                                    libbio::fastq_reader_delegate {
+ private:
+  libbio::fasta_reader m_fasta_reader;
+  libbio::fastq_reader m_fastq_reader;
 
-		libbio::file_handle			m_handle;
-		libbio::gzip_reading_handle	m_gzip_handle;
-		std::string					m_input_path;
+  libbio::file_handle m_handle;
+  libbio::gzip_reading_handle m_gzip_handle;
+  std::string m_input_path;
 
-		libbio::sequence_reader		*m_reader{};
-		libbio::reading_handle		*m_reading_handle{};
+  libbio::sequence_reader* m_reader{};
+  libbio::reading_handle* m_reading_handle{};
 
-		std::size_t					m_parsing_block_size{};
-		std::uint64_t				m_skipped_reads{};
-		bool						m_should_report_errors{};
-		bool						m_read_is_valid{};
-		bool						m_next_read_is_reverse_complement{};
+  std::size_t m_parsing_block_size{};
+  std::uint64_t m_skipped_reads{};
+  bool m_should_report_errors{};
+  bool m_read_is_valid{};
+  bool m_next_read_is_reverse_complement{};
 
-	public:
-		constexpr libbio_reader_adapter() = default;
+ public:
+  constexpr libbio_reader_adapter() = default;
 
-		explicit libbio_reader_adapter(reader_adapter_delegate &delegate):
-			reader_adapter(delegate)
-		{
-			m_fasta_reader.set_delegate(*this);
-			m_fastq_reader.set_delegate(*this);
-			m_handle.prepare();
-			m_gzip_handle.prepare();
-		}
+  explicit libbio_reader_adapter(reader_adapter_delegate& delegate)
+      : reader_adapter(delegate) {
+    m_fasta_reader.set_delegate(*this);
+    m_fastq_reader.set_delegate(*this);
+    m_handle.prepare();
+    m_gzip_handle.prepare();
+  }
 
-		libbio_reader_adapter(libbio_reader_adapter const &) = delete;
-		libbio_reader_adapter(libbio_reader_adapter &&) = default;
-		libbio_reader_adapter &operator=(libbio_reader_adapter const &) = delete;
-		libbio_reader_adapter &operator=(libbio_reader_adapter &&) & = default;
+  libbio_reader_adapter(libbio_reader_adapter const&) = delete;
+  libbio_reader_adapter(libbio_reader_adapter&&) = default;
+  libbio_reader_adapter& operator=(libbio_reader_adapter const&) = delete;
+  libbio_reader_adapter& operator=(libbio_reader_adapter&&) & = default;
 
-		using reader_adapter::read_from_path;
+  using reader_adapter::read_from_path;
 
-		void read_from_path(char const *path) override;
-		bool retrieve_next_read() override;
-		void finish() override;
+  void read_from_path(char const* path) override;
+  bool retrieve_next_read() override;
+  void finish() override;
 
-	private:
-		bool handle_identifier(libbio::fasta_reader_base &, std::string_view, std::span <std::string_view const>) override { return true; }
-		bool handle_sequence_chunk(libbio::fasta_reader_base &reader, std::string_view sv, bool has_newline) override; // The string view does not have the newline character.
-		bool handle_sequence_end(libbio::fasta_reader_base &reader) override { return false; }
+ private:
+  bool handle_identifier(libbio::fasta_reader_base&, std::string_view,
+                         std::span<std::string_view const>) override {
+    return true;
+  }
+  bool handle_sequence_chunk(libbio::fasta_reader_base& reader,
+                             std::string_view sv, bool has_newline)
+      override; // The string view does not have the newline character.
+  bool handle_sequence_end(libbio::fasta_reader_base& reader) override {
+    return false;
+  }
 
-		bool handle_identifier(libbio::fastq_reader_base &, std::string_view) override { return true; }
-		bool handle_sequence_chunk(libbio::fastq_reader_base &reader, std::string_view sv, bool has_newline) override; // The string view does not have the newline character.
-		bool handle_sequence_end(libbio::fastq_reader_base &reader) override { return true; }
-		bool handle_quality_chunk(libbio::fastq_reader_base &, std::string_view, bool) override { return true; }
-		bool handle_quality_end(libbio::fastq_reader_base &) override { return false; }
-	};
-}
+  bool handle_identifier(libbio::fastq_reader_base&,
+                         std::string_view) override {
+    return true;
+  }
+  bool handle_sequence_chunk(libbio::fastq_reader_base& reader,
+                             std::string_view sv, bool has_newline)
+      override; // The string view does not have the newline character.
+  bool handle_sequence_end(libbio::fastq_reader_base& reader) override {
+    return true;
+  }
+  bool handle_quality_chunk(libbio::fastq_reader_base&, std::string_view,
+                            bool) override {
+    return true;
+  }
+  bool handle_quality_end(libbio::fastq_reader_base&) override { return false; }
+};
+}  // namespace sf

--- a/include/libbio_reader_adapter.hpp
+++ b/include/libbio_reader_adapter.hpp
@@ -12,10 +12,15 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 #include "packed_character_iteration.hpp"
 
 
 namespace sf {
+
+	std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos);
+	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst);
+
 
 	class libbio_reader_adapter;
 

--- a/include/libbio_reader_adapter.hpp
+++ b/include/libbio_reader_adapter.hpp
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <libbio/assert.hh>
+#include <libbio/fasta_reader.hh>
+#include <libbio/fastq_reader.hh>
+#include <libbio/file_handle.hh>
+#include <libbio/file_handling.hh>
+#include <libbio/gzip_read_handle.hh>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+#include "libbio/sequence_reader.hh"
+
+namespace sf::detail {
+
+	void reverse_complement_packed_scalar_64b(std::span <std::uint64_t> packed_input, std::uint64_t const length);
+}
+
+
+namespace sf {
+
+	class libbio_reader_adapter final : public libbio::fasta_reader_delegate, libbio::fastq_reader_delegate
+	{
+	public:
+		typedef std::vector <std::uint64_t> read_buffer_type;
+
+	private:
+		struct iteration_context
+		{
+			std::uint64_t const start_idx{};
+			std::uint64_t const shift_amt{};
+			std::uint64_t const mask{};
+
+			std::uint64_t const word_count{};
+			std::uint64_t const last_word_idx{};
+
+			std::uint64_t current_word{};
+			std::uint64_t next_word{};
+
+		public:
+			iteration_context(
+				read_buffer_type const &read_buffer,
+				std::uint64_t read_length,
+				std::uint64_t start_pos
+			):
+				start_idx{start_pos / 32U},
+				shift_amt{2U * (start_pos % 32U)},
+				mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) << shift_amt)},
+				word_count{(read_length - start_pos + 31U) / 32U},
+				last_word_idx{(read_length + 31U) / 32U - start_pos / 32U},
+				next_word{read_buffer[start_idx]}
+			{
+			}
+
+			iteration_context(
+				read_buffer_type const &read_buffer,
+				std::uint64_t read_length,
+				std::uint64_t start_pos,
+				std::uint64_t limit
+			):
+				start_idx{start_pos / 32U},
+				shift_amt{2U * (start_pos % 32U)},
+				mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) << shift_amt)},
+				word_count{(limit - start_pos + 31U) / 32U},
+				last_word_idx{(read_length + 31U) / 32U - (limit - 1) / 32U},
+				next_word{read_buffer[start_idx]}
+			{
+			}
+
+			inline void update(std::uint64_t ww);
+			void rotate_current_word() { current_word = std::rotl(current_word, 2); }
+		};
+
+	private:
+		libbio::fasta_reader		m_fasta_reader;
+		libbio::fastq_reader		m_fastq_reader;
+
+		libbio::file_handle			m_handle;
+		libbio::gzip_reading_handle	m_gzip_handle;
+
+		read_buffer_type			m_read_buffer;
+		std::uint64_t				m_read_length{};
+
+		libbio::sequence_reader		*m_reader{};
+		libbio::reading_handle		*m_reading_handle{};
+
+		bool						m_read_is_valid{};
+		bool						m_next_read_is_reverse_complement{};
+
+	public:
+		libbio_reader_adapter()
+		{
+			m_fasta_reader.set_delegate(*this);
+			m_fastq_reader.set_delegate(*this);
+			m_handle.prepare();
+			m_gzip_handle.prepare();
+		}
+
+		// We pass this to m_fasta_reader and m_fastq_reader, so moving and copying are disabled for now.
+		libbio_reader_adapter(libbio_reader_adapter const &) = delete;
+		libbio_reader_adapter(libbio_reader_adapter &&) = delete;
+		libbio_reader_adapter &operator=(libbio_reader_adapter const &) = delete;
+		libbio_reader_adapter &operator=(libbio_reader_adapter &&) = delete;
+
+		void read_from_path(std::string const &path) { read_from_path(path.c_str()); }
+		void read_from_path(char const *path);
+		bool retrieve_next_read();
+
+		std::uint64_t read_length() const { return m_read_length; }
+		read_buffer_type const &read_buffer() const { return m_read_buffer; }
+
+		template <typename t_cb>
+		void iterate_characters(std::uint64_t start_pos, t_cb &&cb) const;
+
+		template <typename t_cb>
+		void iterate_character_pairs(std::uint64_t start_lhs, std::uint64_t const limit_lhs, std::uint64_t start_rhs, t_cb &&cb) const;
+
+	private:
+		bool handle_identifier(libbio::fasta_reader_base &, std::string_view, std::span <std::string_view const>) override { return true; }
+		bool handle_sequence_chunk(libbio::fasta_reader_base &reader, std::string_view sv, bool has_newline) override; // The string view does not have the newline character.
+		bool handle_sequence_end(libbio::fasta_reader_base &reader) override;
+
+		bool handle_identifier(libbio::fastq_reader_base &, std::string_view) override { return true; }
+		bool handle_sequence_chunk(libbio::fastq_reader_base &reader, std::string_view sv, bool has_newline) override; // The string view does not have the newline character.
+		bool handle_sequence_end(libbio::fastq_reader_base &reader) override;
+		bool handle_quality_chunk(libbio::fastq_reader_base &, std::string_view, bool) override { return true; }
+		bool handle_quality_end(libbio::fastq_reader_base &) override { return true; }
+	};
+
+
+	void libbio_reader_adapter::iteration_context::update(std::uint64_t word_)
+	{
+		current_word = next_word << shift_amt;
+		next_word = std::rotl(word_, shift_amt);
+		current_word |= next_word & mask;
+	}
+
+
+	template <typename t_cb>
+	void libbio_reader_adapter::iterate_characters(std::uint64_t const start_pos, t_cb &&cb) const
+	{
+		if (m_read_length <= start_pos)
+			return;
+
+		iteration_context ctx{m_read_buffer, m_read_length, start_pos};
+		std::uint8_t const remaining_characters((m_read_length - start_pos) % 32U ?: 32U);
+
+		for (std::uint64_t ii{1}; ii < ctx.word_count; ++ii)
+		{
+			ctx.update(m_read_buffer[ctx.start_idx + ii]);
+			for (std::uint8_t jj{}; jj < 32U; ++jj)
+			{
+				ctx.rotate_current_word();
+				cb(ctx.current_word & 0x3);
+			}
+		}
+
+		ctx.update(m_read_buffer[ctx.last_word_idx]); // It does not matter if we reload the last word.
+		for (std::uint8_t jj{}; jj < remaining_characters; ++jj)
+		{
+			ctx.rotate_current_word();
+			cb(ctx.current_word & 0x3);
+		}
+	}
+
+
+	template <typename t_cb>
+	void libbio_reader_adapter::iterate_character_pairs(std::uint64_t const lhs_start_pos, std::uint64_t const lhs_limit, std::uint64_t const rhs_start_pos, t_cb &&cb) const
+	{
+		libbio_assert_lte(lhs_start_pos, rhs_start_pos);
+
+		if (m_read_length <= rhs_start_pos)
+			return;
+
+		iteration_context lhs_ctx{m_read_buffer, m_read_length, lhs_start_pos, lhs_limit};
+		iteration_context rhs_ctx{m_read_buffer, m_read_length, rhs_start_pos};
+		std::uint8_t const rhs_remaining_characters((m_read_length - rhs_start_pos) % 32U ?: 32U);
+		for (std::uint64_t ii{1}; ii < rhs_ctx.word_count; ++ii)
+		{
+			lhs_ctx.update(m_read_buffer[lhs_ctx.start_idx + ii]);
+			rhs_ctx.update(m_read_buffer[rhs_ctx.start_idx + ii]);
+			for (std::uint8_t jj{}; jj < 32U; ++jj)
+			{
+				lhs_ctx.rotate_current_word();
+				rhs_ctx.rotate_current_word();
+				cb(lhs_ctx.current_word & 0x3, rhs_ctx.current_word & 0x3);
+			}
+		}
+
+		lhs_ctx.update(m_read_buffer[lhs_ctx.last_word_idx]);
+		rhs_ctx.update(m_read_buffer[rhs_ctx.last_word_idx]);
+		for (std::uint8_t jj{}; jj < rhs_remaining_characters; ++jj)
+		{
+			lhs_ctx.rotate_current_word();
+			rhs_ctx.rotate_current_word();
+			cb(lhs_ctx.current_word & 0x3, rhs_ctx.current_word & 0x3);
+		}
+	}
+}

--- a/include/pack_characters.hpp
+++ b/include/pack_characters.hpp
@@ -8,9 +8,12 @@
 
 
 namespace sf {
-	typedef std::vector <std::uint64_t> packed_word_vector;
+typedef std::vector<std::uint64_t> packed_word_vector;
 
-	[[nodiscard]] std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos);
-	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst);
-	void print_read(std::span <std::uint64_t const> span, std::uint64_t len);
-}
+[[nodiscard]] std::uint64_t pack_characters(std::string_view sv,
+                                            std::vector<std::uint64_t>& dst,
+                                            std::uint64_t dst_pos);
+void unpack_characters(std::vector<std::uint64_t> const& src,
+                       std::uint64_t length, std::string& dst);
+void print_read(std::span<std::uint64_t const> span, std::uint64_t len);
+}  // namespace sf

--- a/include/pack_characters.hpp
+++ b/include/pack_characters.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+
+namespace sf {
+	typedef std::vector <std::uint64_t> packed_word_vector;
+
+	[[nodiscard]] std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos);
+	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst);
+	void print_read(std::span <std::uint64_t const> span, std::uint64_t len);
+}

--- a/include/packed_character_iteration.hpp
+++ b/include/packed_character_iteration.hpp
@@ -10,6 +10,8 @@
 
 namespace sf::detail {
 
+// The purpose is to maintain the state while iterating
+// characters or pairs of characters in a packed string.
 class packed_character_iteration_context {
  private:
   std::uint64_t const m_shift_amt{};
@@ -53,8 +55,8 @@ void packed_character_iteration_context::update(std::uint64_t word_) {
 
 namespace sf {
 
-        // To iterate the characters, we have cases like the following:
-        // – One word encloses the character range.
+// To iterate the characters, we have cases like the following:
+// – One word encloses the character range.
 // – j words enclose the character range but there are less than (j - 2) * 32
 // characters in total. – j words enclose the character range and there are at
 // least (j - 1) * 32 characters in total.

--- a/include/packed_character_iteration.hpp
+++ b/include/packed_character_iteration.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <libbio/assert.hh>
+#include <vector>
+
+namespace sf {
+	typedef std::vector <std::uint64_t> packed_word_vector;
+}
+
+
+namespace sf::detail {
+
+	class packed_character_iteration_context
+	{
+	private:
+		std::uint64_t const m_shift_amt{};
+		std::uint64_t const m_mask{};
+		std::uint64_t const m_first_word_index{};
+		std::uint64_t const m_last_word_index{};
+		std::uint64_t const m_word_count{};
+
+		std::uint64_t m_current_word{};
+		std::uint64_t m_next_word{};
+
+	public:
+		packed_character_iteration_context(
+			packed_word_vector const &read_buffer,
+			std::uint64_t start_pos,
+			std::uint64_t limit
+		):
+			m_shift_amt{2U * (start_pos % 32U)},
+			m_mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) << m_shift_amt)},
+			m_first_word_index(start_pos / 32U),
+			m_last_word_index((limit - 1U) / 32U),
+			m_word_count((limit - start_pos + 31U) / 32U),
+			m_next_word{read_buffer[m_first_word_index] << m_shift_amt}
+		{
+		}
+
+		inline void update(std::uint64_t ww);
+		void rotate_current_word() { m_current_word = std::rotl(m_current_word, 2); }
+
+		std::uint64_t word_count() const { return m_word_count; }
+		std::uint64_t first_word_index() const { return m_first_word_index; }
+		std::uint64_t last_word_index() const { return m_last_word_index; }
+		std::uint64_t current_word() const { return m_current_word; }
+	};
+
+
+	void packed_character_iteration_context::update(std::uint64_t word_)
+	{
+		m_current_word = m_next_word;
+		m_next_word = std::rotl(word_, m_shift_amt);
+		m_current_word |= m_next_word & m_mask;
+		m_next_word &= ~m_mask;
+	}
+}
+
+
+namespace sf {
+
+	// To iterate the characters, we have cases like the following:
+	// – One word encloses the character range.
+	// – j words enclose the character range but there are less than (j - 2) * 32 characters in total.
+	// – j words enclose the character range and there are at least (j - 1) * 32 characters in total.
+	template <typename t_cb>
+	inline void iterate_packed_characters(
+		packed_word_vector const &src,
+		std::uint64_t length,
+		std::uint64_t const start_pos,
+		t_cb &&cb
+	)
+	{
+		if (length <= start_pos)
+			return;
+
+		detail::packed_character_iteration_context ctx{src, start_pos, length};
+		std::uint8_t const remaining_characters((length - start_pos) % 32U ?: 32U);
+
+		for (std::uint64_t ii{1}; ii < ctx.word_count(); ++ii)
+		{
+			ctx.update(src[ctx.first_word_index() + ii]);
+			for (std::uint8_t jj{}; jj < 32U; ++jj)
+			{
+				ctx.rotate_current_word();
+				cb(ctx.current_word() & 0x3);
+			}
+		}
+
+		// It does not matter if we reload the last word since we only handle
+		// the first remaining_characters characters.
+		ctx.update(src[ctx.last_word_index()]);
+		for (std::uint8_t jj{}; jj < remaining_characters; ++jj)
+		{
+			ctx.rotate_current_word();
+			cb(ctx.current_word() & 0x3);
+		}
+	}
+
+
+	template <typename t_cb>
+	inline void iterate_packed_character_pairs(
+		packed_word_vector const &src,
+		std::uint64_t length,
+		std::uint64_t const lhs_start_pos,
+		std::uint64_t const rhs_start_pos,
+		t_cb &&cb
+	)
+	{
+		if (length <= rhs_start_pos)
+			return;
+
+		libbio_assert_lte(lhs_start_pos, rhs_start_pos);
+
+		detail::packed_character_iteration_context lhs_ctx{src, lhs_start_pos, length};
+		detail::packed_character_iteration_context rhs_ctx{src, rhs_start_pos, length};
+		std::uint8_t const rhs_remaining_characters((length - rhs_start_pos) % 32U ?: 32U);
+
+		// Could not come up with a way to eliminate this branch.
+		auto const lhs_last_word_idx{
+			lhs_ctx.word_count() == rhs_ctx.word_count()
+			? rhs_ctx.last_word_index()
+			: lhs_ctx.first_word_index() + rhs_ctx.word_count()
+		};
+
+		for (std::uint64_t ii{1}; ii < rhs_ctx.word_count(); ++ii)
+		{
+			lhs_ctx.update(src[lhs_ctx.first_word_index() + ii]);
+			rhs_ctx.update(src[rhs_ctx.first_word_index() + ii]);
+			for (std::uint8_t jj{}; jj < 32U; ++jj)
+			{
+				lhs_ctx.rotate_current_word();
+				rhs_ctx.rotate_current_word();
+				cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
+			}
+		}
+
+		// It does not matter if we reload the last word since we only handle
+		// the first remaining_characters characters.
+		lhs_ctx.update(src[lhs_last_word_idx]);
+		rhs_ctx.update(src[rhs_ctx.last_word_index()]);
+		for (std::uint8_t jj{}; jj < rhs_remaining_characters; ++jj)
+		{
+			lhs_ctx.rotate_current_word();
+			rhs_ctx.rotate_current_word();
+			cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
+		}
+	}
+}

--- a/include/packed_character_iteration.hpp
+++ b/include/packed_character_iteration.hpp
@@ -4,11 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <libbio/assert.hh>
-#include <vector>
-
-namespace sf {
-	typedef std::vector <std::uint64_t> packed_word_vector;
-}
+#include "pack_characters.hpp"
 
 
 namespace sf::detail {

--- a/include/packed_character_iteration.hpp
+++ b/include/packed_character_iteration.hpp
@@ -4,145 +4,129 @@
 #include <cstddef>
 #include <cstdint>
 #include <libbio/assert.hh>
+
 #include "pack_characters.hpp"
 
 
 namespace sf::detail {
 
-	class packed_character_iteration_context
-	{
-	private:
-		std::uint64_t const m_shift_amt{};
-		std::uint64_t const m_mask{};
-		std::uint64_t const m_first_word_index{};
-		std::uint64_t const m_last_word_index{};
-		std::uint64_t const m_word_count{};
+class packed_character_iteration_context {
+ private:
+  std::uint64_t const m_shift_amt{};
+  std::uint64_t const m_mask{};
+  std::uint64_t const m_first_word_index{};
+  std::uint64_t const m_last_word_index{};
+  std::uint64_t const m_word_count{};
 
-		std::uint64_t m_current_word{};
-		std::uint64_t m_next_word{};
+  std::uint64_t m_current_word{};
+  std::uint64_t m_next_word{};
 
-	public:
-		packed_character_iteration_context(
-			packed_word_vector const &read_buffer,
-			std::uint64_t start_pos,
-			std::uint64_t limit
-		):
-			m_shift_amt{2U * (start_pos % 32U)},
-			m_mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) << m_shift_amt)},
-			m_first_word_index(start_pos / 32U),
-			m_last_word_index((limit - 1U) / 32U),
-			m_word_count((limit - start_pos + 31U) / 32U),
-			m_next_word{read_buffer[m_first_word_index] << m_shift_amt}
-		{
-		}
+ public:
+  packed_character_iteration_context(packed_word_vector const& read_buffer,
+                                     std::uint64_t start_pos,
+                                     std::uint64_t limit)
+      : m_shift_amt{2U * (start_pos % 32U)},
+        m_mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) << m_shift_amt)},
+        m_first_word_index(start_pos / 32U),
+        m_last_word_index((limit - 1U) / 32U),
+        m_word_count((limit - start_pos + 31U) / 32U),
+        m_next_word{read_buffer[m_first_word_index] << m_shift_amt} {}
 
-		inline void update(std::uint64_t ww);
-		void rotate_current_word() { m_current_word = std::rotl(m_current_word, 2); }
+  inline void update(std::uint64_t ww);
+  void rotate_current_word() { m_current_word = std::rotl(m_current_word, 2); }
 
-		std::uint64_t word_count() const { return m_word_count; }
-		std::uint64_t first_word_index() const { return m_first_word_index; }
-		std::uint64_t last_word_index() const { return m_last_word_index; }
-		std::uint64_t current_word() const { return m_current_word; }
-	};
+  std::uint64_t word_count() const { return m_word_count; }
+  std::uint64_t first_word_index() const { return m_first_word_index; }
+  std::uint64_t last_word_index() const { return m_last_word_index; }
+  std::uint64_t current_word() const { return m_current_word; }
+};
 
 
-	void packed_character_iteration_context::update(std::uint64_t word_)
-	{
-		m_current_word = m_next_word;
-		m_next_word = std::rotl(word_, m_shift_amt);
-		m_current_word |= m_next_word & m_mask;
-		m_next_word &= ~m_mask;
-	}
+void packed_character_iteration_context::update(std::uint64_t word_) {
+  m_current_word = m_next_word;
+  m_next_word = std::rotl(word_, m_shift_amt);
+  m_current_word |= m_next_word & m_mask;
+  m_next_word &= ~m_mask;
 }
+}  // namespace sf::detail
 
 
 namespace sf {
 
-	// To iterate the characters, we have cases like the following:
-	// – One word encloses the character range.
-	// – j words enclose the character range but there are less than (j - 2) * 32 characters in total.
-	// – j words enclose the character range and there are at least (j - 1) * 32 characters in total.
-	template <typename t_cb>
-	inline void iterate_packed_characters(
-		packed_word_vector const &src,
-		std::uint64_t length,
-		std::uint64_t const start_pos,
-		t_cb &&cb
-	)
-	{
-		if (length <= start_pos)
-			return;
+        // To iterate the characters, we have cases like the following:
+        // – One word encloses the character range.
+// – j words enclose the character range but there are less than (j - 2) * 32
+// characters in total. – j words enclose the character range and there are at
+// least (j - 1) * 32 characters in total.
+template <typename t_cb>
+inline void iterate_packed_characters(packed_word_vector const& src,
+                                      std::uint64_t length,
+                                      std::uint64_t const start_pos,
+                                      t_cb&& cb) {
+  if (length <= start_pos) return;
 
-		detail::packed_character_iteration_context ctx{src, start_pos, length};
-		std::uint8_t const remaining_characters((length - start_pos) % 32U ?: 32U);
+  detail::packed_character_iteration_context ctx{src, start_pos, length};
+  std::uint8_t const remaining_characters((length - start_pos) % 32U ?: 32U);
 
-		for (std::uint64_t ii{1}; ii < ctx.word_count(); ++ii)
-		{
-			ctx.update(src[ctx.first_word_index() + ii]);
-			for (std::uint8_t jj{}; jj < 32U; ++jj)
-			{
-				ctx.rotate_current_word();
-				cb(ctx.current_word() & 0x3);
-			}
-		}
+  for (std::uint64_t ii{1}; ii < ctx.word_count(); ++ii) {
+    ctx.update(src[ctx.first_word_index() + ii]);
+    for (std::uint8_t jj{}; jj < 32U; ++jj) {
+      ctx.rotate_current_word();
+      cb(ctx.current_word() & 0x3);
+    }
+  }
 
-		// It does not matter if we reload the last word since we only handle
-		// the first remaining_characters characters.
-		ctx.update(src[ctx.last_word_index()]);
-		for (std::uint8_t jj{}; jj < remaining_characters; ++jj)
-		{
-			ctx.rotate_current_word();
-			cb(ctx.current_word() & 0x3);
-		}
-	}
-
-
-	template <typename t_cb>
-	inline void iterate_packed_character_pairs(
-		packed_word_vector const &src,
-		std::uint64_t length,
-		std::uint64_t const lhs_start_pos,
-		std::uint64_t const rhs_start_pos,
-		t_cb &&cb
-	)
-	{
-		if (length <= rhs_start_pos)
-			return;
-
-		libbio_assert_lte(lhs_start_pos, rhs_start_pos);
-
-		detail::packed_character_iteration_context lhs_ctx{src, lhs_start_pos, length};
-		detail::packed_character_iteration_context rhs_ctx{src, rhs_start_pos, length};
-		std::uint8_t const rhs_remaining_characters((length - rhs_start_pos) % 32U ?: 32U);
-
-		// Could not come up with a way to eliminate this branch.
-		auto const lhs_last_word_idx{
-			lhs_ctx.word_count() == rhs_ctx.word_count()
-			? rhs_ctx.last_word_index()
-			: lhs_ctx.first_word_index() + rhs_ctx.word_count()
-		};
-
-		for (std::uint64_t ii{1}; ii < rhs_ctx.word_count(); ++ii)
-		{
-			lhs_ctx.update(src[lhs_ctx.first_word_index() + ii]);
-			rhs_ctx.update(src[rhs_ctx.first_word_index() + ii]);
-			for (std::uint8_t jj{}; jj < 32U; ++jj)
-			{
-				lhs_ctx.rotate_current_word();
-				rhs_ctx.rotate_current_word();
-				cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
-			}
-		}
-
-		// It does not matter if we reload the last word since we only handle
-		// the first remaining_characters characters.
-		lhs_ctx.update(src[lhs_last_word_idx]);
-		rhs_ctx.update(src[rhs_ctx.last_word_index()]);
-		for (std::uint8_t jj{}; jj < rhs_remaining_characters; ++jj)
-		{
-			lhs_ctx.rotate_current_word();
-			rhs_ctx.rotate_current_word();
-			cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
-		}
-	}
+  // It does not matter if we reload the last word since we only handle
+  // the first remaining_characters characters.
+  ctx.update(src[ctx.last_word_index()]);
+  for (std::uint8_t jj{}; jj < remaining_characters; ++jj) {
+    ctx.rotate_current_word();
+    cb(ctx.current_word() & 0x3);
+  }
 }
+
+
+template <typename t_cb>
+inline void iterate_packed_character_pairs(packed_word_vector const& src,
+                                           std::uint64_t length,
+                                           std::uint64_t const lhs_start_pos,
+                                           std::uint64_t const rhs_start_pos,
+                                           t_cb&& cb) {
+  if (length <= rhs_start_pos) return;
+
+  libbio_assert_lte(lhs_start_pos, rhs_start_pos);
+
+  detail::packed_character_iteration_context lhs_ctx{src, lhs_start_pos,
+                                                     length};
+  detail::packed_character_iteration_context rhs_ctx{src, rhs_start_pos,
+                                                     length};
+  std::uint8_t const rhs_remaining_characters((length - rhs_start_pos) % 32U
+                                                  ?: 32U);
+
+  // Could not come up with a way to eliminate this branch.
+  auto const lhs_last_word_idx{lhs_ctx.word_count() == rhs_ctx.word_count()
+                                   ? rhs_ctx.last_word_index()
+                                   : lhs_ctx.first_word_index() +
+                                         rhs_ctx.word_count()};
+
+  for (std::uint64_t ii{1}; ii < rhs_ctx.word_count(); ++ii) {
+    lhs_ctx.update(src[lhs_ctx.first_word_index() + ii]);
+    rhs_ctx.update(src[rhs_ctx.first_word_index() + ii]);
+    for (std::uint8_t jj{}; jj < 32U; ++jj) {
+      lhs_ctx.rotate_current_word();
+      rhs_ctx.rotate_current_word();
+      cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
+    }
+  }
+
+  // It does not matter if we reload the last word since we only handle
+  // the first remaining_characters characters.
+  lhs_ctx.update(src[lhs_last_word_idx]);
+  rhs_ctx.update(src[rhs_ctx.last_word_index()]);
+  for (std::uint8_t jj{}; jj < rhs_remaining_characters; ++jj) {
+    lhs_ctx.rotate_current_word();
+    rhs_ctx.rotate_current_word();
+    cb(lhs_ctx.current_word() & 0x3, rhs_ctx.current_word() & 0x3);
+  }
+}
+}  // namespace sf

--- a/include/packed_character_iteration.hpp
+++ b/include/packed_character_iteration.hpp
@@ -10,7 +10,7 @@
 
 namespace sf::detail {
 
-// The purpose is to maintain the state while iterating
+// The purpose of this class is to maintain the state while iterating
 // characters or pairs of characters in a packed string.
 class packed_character_iteration_context {
  private:
@@ -94,14 +94,14 @@ inline void iterate_packed_character_pairs(packed_word_vector const& src,
                                            std::uint64_t const lhs_start_pos,
                                            std::uint64_t const rhs_start_pos,
                                            t_cb&& cb) {
+  typedef detail::packed_character_iteration_context context_type;
+
   if (length <= rhs_start_pos) return;
 
   libbio_assert_lte(lhs_start_pos, rhs_start_pos);
 
-  detail::packed_character_iteration_context lhs_ctx{src, lhs_start_pos,
-                                                     length};
-  detail::packed_character_iteration_context rhs_ctx{src, rhs_start_pos,
-                                                     length};
+  context_type lhs_ctx{src, lhs_start_pos, length};
+  context_type rhs_ctx{src, rhs_start_pos, length};
   std::uint8_t const rhs_remaining_characters((length - rhs_start_pos) % 32U
                                                   ?: 32U);
 

--- a/include/partial_count.hpp
+++ b/include/partial_count.hpp
@@ -114,28 +114,7 @@ class partial_count {
         for (; gap_s < gap_lim; ++gap_s) {
           for (uint8_t gap_l = 1; gap_l <= max_gap; ++gap_l) {
             auto const tail_start{gap_s + gap_l};
-            g = [&] {
-              auto const tail_length{k - gap_s};
-              std::uint64_t const head_mask{~(~std::uint64_t{} << gap_s)
-                                            << tail_length};
-              std::uint64_t const head{(read_buffer.front() >> (64U - 2U * k)) &
-                                       head_mask};
-
-              auto const tail_start_word_idx{tail_start / 32U};
-              auto const tail_start_chr_idx{tail_start % 32U};
-              auto const tail_end_word_idx{(tail_start + tail_length) / 32U};
-              std::uint64_t tail{read_buffer[tail_start_word_idx] >>
-                                 (2U * tail_start_chr_idx)};
-
-              if (tail_start_word_idx != tail_end_word_idx) {
-                tail <<= 2U * (tail_length - (32U - tail_start_chr_idx));
-                tail |= read_buffer[tail_end_word_idx] >>
-                        2U * (64U - tail_length - tail_start_chr_idx);
-              }
-
-              return gapmer_t(head | tail, k, gap_s, gap_l);
-            }();
-
+            g = gapmer_t(read_buffer, k, gap_s, gap_l);
             inc(g);
             reader_adapter.iterate_character_pairs(
                 gap_s, tail_start,

--- a/include/reader_adapter.hpp
+++ b/include/reader_adapter.hpp
@@ -3,56 +3,62 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+
 #include "pack_characters.hpp"
 #include "packed_character_iteration.hpp"
 
 
 namespace sf {
 
-	class reader_adapter; // Fwd.
+class reader_adapter; // Fwd.
 
 
-	struct reader_adapter_delegate
-	{
-		virtual ~reader_adapter_delegate() {}
-		virtual bool should_report_errors_for_path(reader_adapter &adapter, std::string_view path) = 0;
-		virtual void found_first_read_with_unexpected_character(reader_adapter &adapter, std::string_view path, std::uint64_t lineno) = 0;
-		virtual void found_total_reads_with_unexpected_characters(reader_adapter &adapter, std::string_view path, std::uint64_t count) = 0;
-	};
+struct reader_adapter_delegate {
+  virtual ~reader_adapter_delegate() {}
+  virtual bool should_report_errors_for_path(reader_adapter& adapter,
+                                             std::string_view path) = 0;
+  virtual void found_first_read_with_unexpected_character(
+      reader_adapter& adapter, std::string_view path, std::uint64_t lineno) = 0;
+  virtual void found_total_reads_with_unexpected_characters(
+      reader_adapter& adapter, std::string_view path, std::uint64_t count) = 0;
+};
 
 
-	class reader_adapter
-	{
-	public:
-		typedef packed_word_vector read_buffer_type;
+class reader_adapter {
+ public:
+  typedef packed_word_vector read_buffer_type;
 
-	protected:
-		read_buffer_type			m_read_buffer;
-		reader_adapter_delegate		*m_delegate{};
-		std::uint64_t				m_read_length{};
+ protected:
+  read_buffer_type m_read_buffer;
+  reader_adapter_delegate* m_delegate{};
+  std::uint64_t m_read_length{};
 
-	public:
-		constexpr reader_adapter() = default;
+ public:
+  constexpr reader_adapter() = default;
 
-		explicit reader_adapter(reader_adapter_delegate &delegate):
-			m_delegate(&delegate)
-		{
-		}
+  explicit reader_adapter(reader_adapter_delegate& delegate)
+      : m_delegate(&delegate) {}
 
-		virtual ~reader_adapter() {}
+  virtual ~reader_adapter() {}
 
-		virtual void read_from_path(char const *path) = 0;
-		void read_from_path(std::string const &path) { read_from_path(path.c_str()); }
-		virtual bool retrieve_next_read() = 0;
-		virtual void finish() = 0;
+  virtual void read_from_path(char const* path) = 0;
+  void read_from_path(std::string const& path) { read_from_path(path.c_str()); }
+  virtual bool retrieve_next_read() = 0;
+  virtual void finish() = 0;
 
-		std::uint64_t read_length() const { return m_read_length; }
-		read_buffer_type const &read_buffer() const { return m_read_buffer; }
+  std::uint64_t read_length() const { return m_read_length; }
+  read_buffer_type const& read_buffer() const { return m_read_buffer; }
 
-		template <typename t_cb>
-		void iterate_characters(std::uint64_t start_pos, t_cb &&cb) const { iterate_packed_characters(m_read_buffer, m_read_length, start_pos, cb); }
+  template <typename t_cb>
+  void iterate_characters(std::uint64_t start_pos, t_cb&& cb) const {
+    iterate_packed_characters(m_read_buffer, m_read_length, start_pos, cb);
+  }
 
-		template <typename t_cb>
-		void iterate_character_pairs(std::uint64_t lhs_start, std::uint64_t rhs_start, t_cb &&cb) const { iterate_packed_character_pairs(m_read_buffer, m_read_length, lhs_start, rhs_start, cb); }
-	};
-}
+  template <typename t_cb>
+  void iterate_character_pairs(std::uint64_t lhs_start, std::uint64_t rhs_start,
+                               t_cb&& cb) const {
+    iterate_packed_character_pairs(m_read_buffer, m_read_length, lhs_start,
+                                   rhs_start, cb);
+  }
+};
+}  // namespace sf

--- a/include/reader_adapter.hpp
+++ b/include/reader_adapter.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include "packed_character_iteration.hpp"
+
+
+namespace sf {
+
+	class reader_adapter; // Fwd.
+
+
+	struct reader_adapter_delegate
+	{
+		virtual ~reader_adapter_delegate() {}
+		virtual bool should_report_errors_for_path(reader_adapter &adapter, std::string_view path) = 0;
+		virtual void found_first_read_with_unexpected_character(reader_adapter &adapter, std::string_view path, std::uint64_t lineno) = 0;
+		virtual void found_total_reads_with_unexpected_characters(reader_adapter &adapter, std::string_view path, std::uint64_t count) = 0;
+	};
+
+
+	class reader_adapter
+	{
+	public:
+		typedef packed_word_vector read_buffer_type;
+
+	protected:
+		read_buffer_type			m_read_buffer;
+		reader_adapter_delegate		*m_delegate{};
+		std::uint64_t				m_read_length{};
+
+	public:
+		constexpr reader_adapter() = default;
+
+		explicit reader_adapter(reader_adapter_delegate &delegate):
+			m_delegate(&delegate)
+		{
+		}
+
+		virtual ~reader_adapter() {}
+
+		virtual void read_from_path(char const *path) = 0;
+		void read_from_path(std::string const &path) { read_from_path(path.c_str()); }
+		virtual bool retrieve_next_read() = 0;
+		virtual void finish() = 0;
+
+		std::uint64_t read_length() const { return m_read_length; }
+		read_buffer_type const &read_buffer() const { return m_read_buffer; }
+
+		template <typename t_cb>
+		void iterate_characters(std::uint64_t start_pos, t_cb &&cb) const { iterate_packed_characters(m_read_buffer, m_read_length, start_pos, cb); }
+
+		template <typename t_cb>
+		void iterate_character_pairs(std::uint64_t lhs_start, std::uint64_t rhs_start, t_cb &&cb) const { iterate_packed_character_pairs(m_read_buffer, m_read_length, lhs_start, rhs_start, cb); }
+	};
+}

--- a/include/reader_adapter.hpp
+++ b/include/reader_adapter.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include "pack_characters.hpp"
 #include "packed_character_iteration.hpp"
 
 

--- a/include/reader_adapter.hpp
+++ b/include/reader_adapter.hpp
@@ -15,10 +15,16 @@ class reader_adapter; // Fwd.
 
 struct reader_adapter_delegate {
   virtual ~reader_adapter_delegate() {}
+  /// Return true if the reader_adapter should call the error reporting member
+  /// functions below.
   virtual bool should_report_errors_for_path(reader_adapter& adapter,
                                              std::string_view path) = 0;
+  /// Called when the reader_adapter has found the first read with an unexpected
+  /// (wildcard) character.
   virtual void found_first_read_with_unexpected_character(
       reader_adapter& adapter, std::string_view path, std::uint64_t lineno) = 0;
+  /// Report the total number of reads with unexpected characters. Called after
+  /// processing all the reads.
   virtual void found_total_reads_with_unexpected_characters(
       reader_adapter& adapter, std::string_view path, std::uint64_t count) = 0;
 };
@@ -36,24 +42,33 @@ class reader_adapter {
  public:
   constexpr reader_adapter() = default;
 
+  /// Construct with a delegate, needed to process reads.
   explicit reader_adapter(reader_adapter_delegate& delegate)
       : m_delegate(&delegate) {}
 
   virtual ~reader_adapter() {}
 
+  /// Open the file at the given path.
   virtual void read_from_path(char const* path) = 0;
   void read_from_path(std::string const& path) { read_from_path(path.c_str()); }
+  /// Retrieve the next read.
+  /// \returns true if a read could be retrieved.
   virtual bool retrieve_next_read() = 0;
+  /// Call after finishing with the file.
   virtual void finish() = 0;
 
+  /// Length of the current read.
   std::uint64_t read_length() const { return m_read_length; }
+  /// Access the current read.
   read_buffer_type const& read_buffer() const { return m_read_buffer; }
 
+  /// Iterate the characters of the current read.
   template <typename t_cb>
   void iterate_characters(std::uint64_t start_pos, t_cb&& cb) const {
     iterate_packed_characters(m_read_buffer, m_read_length, start_pos, cb);
   }
 
+  /// Iterate the character pairs of the current read.
   template <typename t_cb>
   void iterate_character_pairs(std::uint64_t lhs_start, std::uint64_t rhs_start,
                                t_cb&& cb) const {

--- a/include/seed_finder.hpp
+++ b/include/seed_finder.hpp
@@ -7,7 +7,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <libbio/utility.hh>
+#include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -15,6 +18,7 @@
 #include "fm_index.hpp"
 #include "gapmer.hpp"
 #include "gapmer_count.hpp"
+#include "libbio_reader_adapter.hpp"
 #include "partial_count.hpp"
 #include "util.hpp"
 
@@ -22,14 +26,16 @@ namespace sf {
 
 template <bool middle_gap_only, uint8_t max_gap, bool enable_smootihing = true,
           bool filter_mers = true>
-class seed_finder {
+class seed_finder : public libbio_reader_adapter_delegate {
  public:
-  typedef gapmer<middle_gap_only, max_gap> G;
+  typedef gapmer<middle_gap_only, max_gap> gapmer_type;
 
  private:
-  typedef gapmer_count<middle_gap_only, max_gap> G_C;
+  typedef gapmer_count<middle_gap_only, max_gap> gapmer_count_type;
+  typedef std::set<std::string, libbio::compare_strings_transparent> path_set;
+
   struct Res {
-    G g;
+    gapmer_type g;
     double p;
     uint64_t sig_count;
     uint64_t bg_count;
@@ -38,6 +44,7 @@ class seed_finder {
   std::string sig_path_;
   std::string bg_path_;
   std::vector<Res> seeds_;
+  path_set paths_with_errors_;
   uint64_t sig_size_;
   uint64_t bg_size_;
   double p_;
@@ -64,9 +71,9 @@ class seed_finder {
    * @return True, if extension from a to b is valid
    */
   template <bool debug = false>
-  bool do_extend([[maybe_unused]] G a, [[maybe_unused]] G b, double a_sig,
-                 double a_bg, double b_sig, double b_bg, double a_r,
-                 double b_r) {
+  bool do_extend([[maybe_unused]] gapmer_type a, [[maybe_unused]] gapmer_type b,
+                 double a_sig, double a_bg, double b_sig, double b_bg,
+                 double a_r, double b_r) {
     if (a_bg <= 1.00001 && b_bg <= 1.00001) {
       if (a_sig > b_sig * 4) {
         return false;
@@ -126,9 +133,9 @@ class seed_finder {
    * == false, else output parameter.
    */
   template <bool calc_b_r>
-  bool do_filter([[maybe_unused]] G a, [[maybe_unused]] G b, double a_sig,
-                 double a_bg, double b_sig, double b_bg, double a_r,
-                 double& b_r) {
+  bool do_filter([[maybe_unused]] gapmer_type a, [[maybe_unused]] gapmer_type b,
+                 double a_sig, double a_bg, double b_sig, double b_bg,
+                 double a_r, double& b_r) {
     if (a_bg <= 1.00001 && b_bg <= 1.00001) {
       if (b_sig > a_sig) {
         if constexpr (calc_b_r) {
@@ -160,13 +167,13 @@ class seed_finder {
    * @param sig_bg_b Length k + 1 gapmer count tables
    */
   void check_count(const uint8_t k, const uint64_t v, uint8_t gap_s,
-                   uint8_t gap_l, uint64_t offset, G_C& sig_bg_a,
-                   G_C& sig_bg_b) {
+                   uint8_t gap_l, uint64_t offset, gapmer_count_type& sig_bg_a,
+                   gapmer_count_type& sig_bg_b) {
 #ifdef DEBUG
-    if (offset + v >= G_C::lookup_elems(k)) {
+    if (offset + v >= gapmer_count_type::lookup_elems(k)) {
       std::cerr << "accessing " << offset << " + " << v << " = " << offset + v
-                << " of " << G_C::lookup_elems(k) << " element table"
-                << std::endl;
+                << " of " << gapmer_count_type::lookup_elems(k)
+                << " element table" << std::endl;
       exit(1);
     }
 #endif
@@ -175,7 +182,7 @@ class seed_finder {
         return;
       }
     }
-    G g(v, k, gap_s, gap_l);
+    gapmer_type g(v, k, gap_s, gap_l);
     if (not g.is_canonical()) {
       if constexpr (filter_mers) {
 #pragma omp critical(a_bv)
@@ -202,7 +209,7 @@ class seed_finder {
     }
     if constexpr (filter_mers) {
       // Length k mers.
-      auto callback_a = [&](G o) {
+      auto callback_a = [&](gapmer_type o) {
         uint64_t o_offset = sig_bg_a.offset(o.gap_start(), o.gap_length());
         uint64_t o_v = o.value();
         double o_a = sig_bg_a.sig_counts[o_offset + o_v] + 1;
@@ -224,7 +231,7 @@ class seed_finder {
       g.template huddinge_neighbours<true, false, true>(callback_a);
 
       // Length k + 1 mers.
-      auto callback_b = [&](G o) {
+      auto callback_b = [&](gapmer_type o) {
         uint64_t o_offset = sig_bg_b.offset(o.gap_start(), o.gap_length());
         uint64_t o_v = o.value();
         double o_a = sig_bg_b.sig_counts[o_offset + o_v] + 1;
@@ -272,12 +279,13 @@ class seed_finder {
    */
   template <class M>
   void filter_count(const uint8_t k, const uint64_t v, uint8_t gap_s,
-                    uint8_t gap_l, uint64_t offset, G_C& sig_bg_c, M& m) {
+                    uint8_t gap_l, uint64_t offset, gapmer_count_type& sig_bg_c,
+                    M& m) {
 #ifdef DEBUG
-    if (offset + v >= G_C::lookup_elems(k)) {
+    if (offset + v >= gapmer_count_type::lookup_elems(k)) {
       std::cerr << "k = " << int(k) << " & sig_bg_c.k_ = " << int(sig_bg_c.k_)
                 << " :\n accessing " << offset << " + " << v << " = "
-                << offset + v << " of " << G_C::lookup_elems(k)
+                << offset + v << " of " << gapmer_count_type::lookup_elems(k)
                 << " element table" << std::endl;
       exit(1);
     }
@@ -287,7 +295,7 @@ class seed_finder {
         return;
       }
     }
-    G g(v, k, gap_s, gap_l);
+    gapmer_type g(v, k, gap_s, gap_l);
     if (not g.is_canonical()) {
       if constexpr (filter_mers) {
 #pragma omp critical(d_bv)
@@ -313,7 +321,7 @@ class seed_finder {
       return;
     }
     if constexpr (filter_mers) {
-      auto callback = [&](G o) {
+      auto callback = [&](gapmer_type o) {
         uint64_t o_offset = sig_bg_c.offset(o.gap_start(), o.gap_length());
         uint64_t o_v = o.value();
         double o_a = sig_bg_c.sig_counts[o_offset + v] + 1;
@@ -349,21 +357,21 @@ class seed_finder {
    * @param sig_bg_c  Ouput parameter, for storing counts for final k-length
    * mers
    */
-  void counted_seeds_and_candidates(G_C& sig_bg_c) {
+  void counted_seeds_and_candidates(gapmer_count_type& sig_bg_c) {
     std::cerr << "Lookup tables up to " << int(lookup_k_) << std::endl;
     // Initialize by counting 5-mers
-    G_C sig_bg_a(sig_path_, bg_path_, 5);
+    gapmer_count_type sig_bg_a(sig_path_, bg_path_, 5, *this);
     if constexpr (enable_smootihing) {
       sig_bg_a.smooth();
     }
 
     for (uint8_t k = 6; k <= lookup_k_; ++k) {
       // Initialize the k + 1 to compute extensions
-      G_C sig_bg_b(sig_path_, bg_path_, k);
+      gapmer_count_type sig_bg_b(sig_path_, bg_path_, k, *this);
       if constexpr (enable_smootihing) {
         sig_bg_b.smooth();
       }
-      uint64_t v_lim = G_C::ONE << ((k - 1) * 2);
+      uint64_t v_lim = gapmer_count_type::ONE << ((k - 1) * 2);
 #pragma omp parallel for
       for (uint64_t v = 0; v < v_lim; ++v) {
         check_count(k - 1, v, 0, 0, 0, sig_bg_a, sig_bg_b);
@@ -374,7 +382,7 @@ class seed_finder {
         for (uint8_t gap_l = 1; gap_l <= max_gap; ++gap_l) {
           uint64_t offset = sig_bg_a.offset(gap_s, gap_l);
 #ifdef DEBUG
-          if (offset >= G_C::lookup_elems(k + 1)) {
+          if (offset >= gapmer_count_type::lookup_elems(k + 1)) {
             std::cerr << "invalid offset " << offset << " for gap start "
                       << int(gap_s) << " and gap length " << int(gap_l)
                       << std::endl;
@@ -418,7 +426,7 @@ class seed_finder {
                 << p.second.sig_count << ", " << p.second.bg_count << ", "
                 << p.second.p << std::endl;
 #endif
-      auto callback = [&](G o) {
+      auto callback = [&](gapmer_type o) {
         if (not o.is_canonical()) {
           o = o.reverse_complement();
         }
@@ -465,13 +473,13 @@ class seed_finder {
   void extend(M& a, M& b, P& p_counter, uint16_t k, bool prune) {
     const constexpr double fill_limit = 0.4;
     std::cerr << "    Extend " << a.size() << " mers." << std::endl;
-    auto hash = [](const G g) { return uint64_t(g); };
-    std::unordered_set<G, decltype(hash)> del_set;
-    auto callback = [&](G o) {
+    auto hash = [](const gapmer_type g) { return uint64_t(g); };
+    std::unordered_set<gapmer_type, decltype(hash)> del_set;
+    auto callback = [&](gapmer_type o) {
       if (not b.contains(o)) {
         p_counter.init(o);
         if constexpr (enable_smootihing) {
-          auto ccb = [&](G h_n) { p_counter.init(h_n); };
+          auto ccb = [&](gapmer_type h_n) { p_counter.init(h_n); };
           o.hamming_neighbours(ccb);
         }
       }
@@ -520,7 +528,7 @@ class seed_finder {
                   << p.second.p << std::endl;
 #endif
         bool keep = true;
-        auto callback_extend = [&](G o) {
+        auto callback_extend = [&](gapmer_type o) {
           if (not o.is_canonical()) {
             o = o.reverse_complement();
           }
@@ -556,8 +564,8 @@ class seed_finder {
    */
   template <class M>
   void filter(M& m) {
-    auto hash = [](const G& g) { return uint64_t(g); };
-    std::unordered_set<G, decltype(hash)> del_set;
+    auto hash = [](const gapmer_type& g) { return uint64_t(g); };
+    std::unordered_set<gapmer_type, decltype(hash)> del_set;
     auto e = m.end();
     for (auto it = m.begin(); it != e; ++it) {
       bool keep = true;
@@ -633,14 +641,14 @@ class seed_finder {
    * candidates
    */
   void find_seeds() {
-    auto hash = [](const G g) { return uint64_t(g); };
-    std::unordered_map<G, Res, decltype(hash)> a;
-    std::unordered_map<G, Res, decltype(hash)> b;
+    auto hash = [](const gapmer_type g) { return uint64_t(g); };
+    std::unordered_map<gapmer_type, Res, decltype(hash)> a;
+    std::unordered_map<gapmer_type, Res, decltype(hash)> b;
     // full k-mer couting as long as memory is sufficient.
     {
-      G_C sig_bg_c;
+      gapmer_count_type sig_bg_c;
       counted_seeds_and_candidates(sig_bg_c);
-      uint64_t v_lim = G_C::ONE << (lookup_k_ * 2);
+      uint64_t v_lim = gapmer_count_type::ONE << (lookup_k_ * 2);
 #pragma omp parallel for
       for (uint64_t v = 0; v < v_lim; ++v) {
         filter_count(lookup_k_, v, 0, 0, 0, sig_bg_c, a);
@@ -658,7 +666,7 @@ class seed_finder {
       }
     }
     // Partial count with extensions when we can no longer count everything
-    partial_count<G> p_counter;
+    partial_count<gapmer_type> p_counter(*this);
     for (uint8_t k = lookup_k_ + 1; k <= k_lim_; ++k) {
       std::cerr << int(k) - 1 << " -> " << std::endl;
       extend(a, b, p_counter, k, prune_);
@@ -691,5 +699,25 @@ class seed_finder {
   const std::vector<Res>& get_seeds() const { return seeds_; }
 
   double x() const { return x_; }
+
+ private:
+  bool should_report_errors_for_path(libbio_reader_adapter&,
+                                     std::string_view path) override {
+    return !paths_with_errors_.contains(path);
+  }
+
+  void found_first_read_with_unexpected_character(
+      libbio_reader_adapter&, std::string_view path,
+      std::uint64_t lineno) override {
+    std::cerr << "WARNING: Skipping reads with unexpected characters in "
+              << path << "; first one on line " << lineno << ".\n";
+  }
+
+  void found_total_reads_with_unexpected_characters(
+      libbio_reader_adapter&, std::string_view path,
+      std::uint64_t count) override {
+    paths_with_errors_.emplace(path);
+    std::cerr << "WARNING: Skipped " << count << " reads in " << path << ".\n";
+  }
 };
 }  // namespace sf

--- a/include/seqio_reader_adapter.hpp
+++ b/include/seqio_reader_adapter.hpp
@@ -1,29 +1,30 @@
 #pragma once
 
+#include <SeqIO/SeqIO.hh>
 #include <cstdint>
 #include <libbio/assert.hh>
 #include <memory>
-#include <SeqIO/SeqIO.hh>
 #include <string>
+
 #include "reader_adapter.hpp"
 
 
 namespace sf {
 
-	class seqio_reader_adapter final : public reader_adapter
-	{
-	private:
-		std::unique_ptr <seq_io::Reader_x>	m_reader{};
-		std::string							m_input_path{};
-		std::uint64_t						m_skipped_reads{};
-		bool								m_should_report_errors{};
+class seqio_reader_adapter final : public reader_adapter {
+ private:
+  // We use a std::unique_ptr here b.c. seq_io::Reader_x is not movable.
+  std::unique_ptr<seq_io::Reader_x> m_reader{};
+  std::string m_input_path{};
+  std::uint64_t m_skipped_reads{};
+  bool m_should_report_errors{};
 
-	public:
-		using reader_adapter::reader_adapter;
-		using reader_adapter::read_from_path;
+ public:
+  using reader_adapter::read_from_path;
+  using reader_adapter::reader_adapter;
 
-		void read_from_path(char const *path) override;
-		bool retrieve_next_read() override;
-		void finish() override;
-	};
-}
+  void read_from_path(char const* path) override;
+  bool retrieve_next_read() override;
+  void finish() override;
+};
+}  // namespace sf

--- a/include/seqio_reader_adapter.hpp
+++ b/include/seqio_reader_adapter.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <libbio/assert.hh>
+#include <memory>
+#include <SeqIO/SeqIO.hh>
+#include <string>
+#include "reader_adapter.hpp"
+
+
+namespace sf {
+
+	class seqio_reader_adapter final : public reader_adapter
+	{
+	private:
+		std::unique_ptr <seq_io::Reader_x>	m_reader{};
+		std::string							m_input_path{};
+		std::uint64_t						m_skipped_reads{};
+		bool								m_should_report_errors{};
+
+	public:
+		using reader_adapter::reader_adapter;
+		using reader_adapter::read_from_path;
+
+		void read_from_path(char const *path) override;
+		bool retrieve_next_read() override;
+		void finish() override;
+	};
+}

--- a/libbio_reader_adapter.cpp
+++ b/libbio_reader_adapter.cpp
@@ -1,0 +1,248 @@
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <libbio/fasta_reader.hh>
+#include <libbio/fastq_reader.hh>
+#include <libbio/file_handle.hh>
+#include <libbio/file_handling.hh>
+#include <libbio/sequence_reader.hh>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "libbio_reader_adapter.hpp"
+
+namespace lb = libbio;
+
+
+namespace {
+
+	std::uint64_t read_into_packed_sequence(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos)
+	{
+		auto const push_packed([](char const cc, std::uint64_t &dst_word, std::uint64_t const dst_pos_) -> bool {
+			auto const chararcter_pos{dst_pos_ % 32U};
+			std::uint64_t const shift_amt{62U - 2 * chararcter_pos};
+			switch (cc)
+			{
+				case 'A':
+				case 'a':
+					break;
+
+				case 'C':
+				case 'c':
+					dst_word |= UINT64_C(0x1) << shift_amt;
+					break;
+
+				case 'G':
+				case 'g':
+					dst_word |= UINT64_C(0x2) << shift_amt;
+					break;
+
+				case 'T':
+				case 't':
+					dst_word |= UINT64_C(0x3) << shift_amt;
+					break;
+
+				[[unlikely]] default:
+					return false;
+			}
+
+			return true;
+		});
+
+		auto it{sv.cbegin()};
+		auto const end{sv.cend()};
+
+		if (dst_pos % 32U)
+		{
+			auto &dst_word{dst.back()};
+			do
+			{
+				if (it == end)
+					return dst_pos;
+
+				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+					return UINT64_MAX;
+
+				++dst_pos;
+				++it;
+			} while (dst_pos % 32U);
+		}
+
+		if (it == end)
+			return dst_pos;
+
+		// 0 == dst_pos % 32U.
+		while (true)
+		{
+			auto &dst_word{dst.emplace_back(0)};
+			do
+			{
+				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+					return UINT64_MAX;
+
+				++dst_pos;
+				++it;
+
+				if (it == end)
+					return dst_pos;
+			} while (dst_pos % 32U);
+
+			if (it == end)
+				return dst_pos;
+		}
+	}
+}
+
+
+namespace sf::detail {
+
+	constexpr inline unsigned char reverse_bits_32b(unsigned char cc)
+	{
+		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
+		return ((cc * UINT32_C(0x0802) & UINT32_C(0x22110)) | (cc * UINT32_C(0x8020) & UINT32_C(0x88440))) * UINT32_C(0x10101) >> 16U;
+	}
+
+
+	constexpr inline unsigned char reverse_bits_64b(unsigned char cc)
+	{
+		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
+		return  ((cc * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101) >> 32U;
+	}
+
+
+	void reverse_complement_packed_scalar_64b(std::span <std::uint64_t> packed_input, std::uint64_t const length)
+	{
+		if (0 == length)
+			return;
+
+		// Reverse the 8-byte words.
+		std::reverse(packed_input.begin(), packed_input.end() - 1);
+
+		auto const reverse_complement([](std::uint64_t word){
+			word = std::byteswap(word);
+
+			auto *bytes{reinterpret_cast <char *>(&word)};
+			bytes[0] = reverse_bits_64b(bytes[0]);
+			bytes[1] = reverse_bits_64b(bytes[1]);
+			bytes[2] = reverse_bits_64b(bytes[2]);
+			bytes[3] = reverse_bits_64b(bytes[3]);
+
+			word = ~word;
+			auto const b1{(word << 1U) & UINT64_C(0xAAAA'AAAA'AAAA'AAAA)};
+			auto const b2{(word >> 1U) & UINT64_C(0x5555'5555'5555'5555)};
+			word = b1 | b2;
+
+			return word;
+		});
+
+		auto const shift_right_amt{(length % 32U) * 2U};
+		auto const mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) >> shift_right_amt)}; // Avoid UB by replacing shift with rotate + bitwise and.
+		packed_input.front() = reverse_complement(packed_input.front());
+		packed_input.front() = std::rotr(packed_input.front(), shift_right_amt);
+		for (std::size_t ii{1U}; ii < packed_input.size() - 1; ++ii)
+		{
+			auto &word(packed_input[ii - 1]);
+			auto &next_word(packed_input[ii]);
+			next_word = reverse_complement(next_word);
+			word |= next_word >> shift_right_amt;
+			next_word = std::rotr(next_word, shift_right_amt) & mask;
+		}
+	}
+}
+
+
+namespace sf {
+
+	void libbio_reader_adapter::read_from_path(char const *path)
+	{
+		std::string_view path_{path};
+
+		m_handle = lb::file_handle(lb::open_file_for_reading(path));
+		if (path_.ends_with(".gz"))
+		{
+			m_gzip_handle.set_gzip_input_handle(m_handle);
+			m_reading_handle = &m_gzip_handle;
+			path_.remove_suffix(3);
+		}
+		else
+		{
+			m_reading_handle = &m_handle;
+		}
+
+		if (path_.ends_with(".fasta") || path_.ends_with(".fa"))
+			m_reader = &m_fasta_reader;
+		else if (path_.ends_with(".fastq") || path_.ends_with(".fq"))
+			m_reader = &m_fastq_reader;
+		else
+		{
+			std::cerr << "FATAL: Unexpected suffix in path “" << path << "”.\n";
+			std::exit(1);
+		}
+
+		m_reader->prepare();
+	}
+
+
+	bool libbio_reader_adapter::retrieve_next_read()
+	{
+		if (m_next_read_is_reverse_complement)
+		{
+			m_next_read_is_reverse_complement = false;
+			detail::reverse_complement_packed_scalar_64b(std::span{m_read_buffer.data(), m_read_buffer.size()}, m_read_length);
+		}
+		else
+		{
+			m_next_read_is_reverse_complement = true;
+
+			while (true)
+			{
+				m_read_buffer.clear();
+				m_read_length = 0;
+				m_read_is_valid = true;
+
+				auto const status{m_reader->parse_(*m_reading_handle)};
+				if (lb::sequence_reader::parsing_status::failure == status || 0 == m_read_length)
+				{
+					m_reading_handle->finish();
+					return false;
+				}
+
+				if (m_read_is_valid)
+					break;
+
+				std::cerr << "Skipping read on line "  << m_reader->line_number() << " due to unexpected character.\n";
+			}
+		}
+
+		return true;
+	}
+
+
+	bool libbio_reader_adapter::handle_sequence_chunk(lb::fasta_reader_base &reader, std::string_view sv, bool has_newline)
+	{
+		m_read_length = read_into_packed_sequence(sv, m_read_buffer, m_read_length);
+		return (UINT64_MAX != m_read_length);
+	}
+
+
+	bool libbio_reader_adapter::handle_sequence_chunk(lb::fastq_reader_base &reader, std::string_view sv, bool has_newline)
+	{
+		m_read_length = read_into_packed_sequence(sv, m_read_buffer, m_read_length);
+		return (UINT64_MAX != m_read_length);
+	}
+
+
+	bool libbio_reader_adapter::handle_sequence_end(lb::fasta_reader_base &reader)
+	{
+		return false;
+	}
+
+
+	bool libbio_reader_adapter::handle_sequence_end(lb::fastq_reader_base &reader)
+	{
+		return false;
+	}
+}

--- a/libbio_reader_adapter.cpp
+++ b/libbio_reader_adapter.cpp
@@ -12,157 +12,10 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <vector>
-
 #include "libbio_reader_adapter.hpp"
+#include "pack_characters.hpp"
 
 namespace lb = libbio;
-
-
-namespace {
-
-	void print_read(std::span <std::uint64_t const> span, std::uint64_t len)
-	{
-		std::cerr << "** read: ";
-		for (auto word : span)
-		{
-			for (std::uint8_t ii{}; ii < 32U; ++ii)
-			{
-				word = std::rotl(word, 2);
-				auto const cc{word & 0x3};
-				switch (cc)
-				{
-					case 0: std::cerr << 'A'; break;
-					case 1: std::cerr << 'C'; break;
-					case 2: std::cerr << 'G'; break;
-					case 3: std::cerr << 'T'; break;
-					default: std::abort();
-				}
-
-				--len;
-				if (0 == len)
-					break;
-			}
-		}
-		std::cerr << '\n';
-	}
-}
-
-
-namespace sf {
-
-	std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos)
-	{
-		auto const push_packed([](char const cc, std::uint64_t &dst_word, std::uint64_t const dst_pos_) -> bool {
-			auto const chararcter_pos{dst_pos_ % 32U};
-			std::uint64_t const shift_amt{62U - 2 * chararcter_pos};
-			switch (cc)
-			{
-				case 'A':
-				case 'a':
-					break;
-
-				case 'C':
-				case 'c':
-					dst_word |= UINT64_C(0x1) << shift_amt;
-					break;
-
-				case 'G':
-				case 'g':
-					dst_word |= UINT64_C(0x2) << shift_amt;
-					break;
-
-				case 'T':
-				case 't':
-					dst_word |= UINT64_C(0x3) << shift_amt;
-					break;
-
-				[[unlikely]] default:
-					return false;
-			}
-
-			return true;
-		});
-
-		auto it{sv.cbegin()};
-		auto const end{sv.cend()};
-
-		if (dst_pos % 32U)
-		{
-			auto &dst_word{dst.back()};
-			do
-			{
-				if (it == end)
-					return dst_pos;
-
-				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
-					return UINT64_MAX;
-
-				++dst_pos;
-				++it;
-			} while (dst_pos % 32U);
-		}
-
-		if (it == end)
-			return dst_pos;
-
-		// 0 == dst_pos % 32U.
-		while (true)
-		{
-			auto &dst_word{dst.emplace_back(0)};
-			do
-			{
-				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
-					return UINT64_MAX;
-
-				++dst_pos;
-				++it;
-
-				if (it == end)
-					return dst_pos;
-			} while (dst_pos % 32U);
-
-			if (it == end)
-				return dst_pos;
-		}
-	}
-
-
-	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst)
-	{
-		auto const append_character([&dst](std::uint64_t const word){
-			switch (word & UINT64_C(0x3))
-			{
-				case 0x0: dst.push_back('A'); break;
-				case 0x1: dst.push_back('C'); break;
-				case 0x2: dst.push_back('G'); break;
-				case 0x3: dst.push_back('T'); break;
-				default: libbio_fail("Unexpected value");
-			}
-		});
-
-		std::uint64_t ii{};
-		while (ii + 32 <= length)
-		{
-			auto word{src[ii / 32]};
-			for (std::uint8_t jj{}; jj < 32; ++jj)
-			{
-				word = std::rotl(word, 2);
-				append_character(word);
-			}
-
-			ii += 32;
-		}
-
-		auto word{src[ii / 32]};
-		while (ii < length)
-		{
-			word = std::rotl(word, 2);
-			append_character(word);
-			++ii;
-		}
-	}
-}
 
 
 namespace sf::detail {
@@ -309,7 +162,7 @@ namespace sf {
 			std::exit(1);
 		}
 
-		m_current_input_path = path_;
+		m_input_path = path_;
 		m_parsing_block_size = m_reading_handle->io_op_blocksize();
 		m_skipped_reads = 0;
 		m_should_report_errors = m_delegate->should_report_errors_for_path(*this, path_);
@@ -346,12 +199,11 @@ namespace sf {
 
 				// Reached if the current read is invalid. We report only the first error.
 				if (0 == m_skipped_reads && m_should_report_errors)
-					std::cerr << "WARNING: Skipping reads with unexpected characters in " << m_current_input_path << "; first one on line " << m_reader->line_number() << ".\n";
+					m_delegate->found_first_read_with_unexpected_character(*this, m_input_path, m_reader->line_number());
 				++m_skipped_reads;
 			}
 		}
 
-		//print_read(std::span{m_read_buffer.data(), m_read_buffer.size()}, m_read_length);
 		return true;
 	}
 
@@ -359,7 +211,7 @@ namespace sf {
 	void libbio_reader_adapter::finish()
 	{
 		if (m_skipped_reads && m_should_report_errors)
-			m_delegate->found_total_reads_with_unexpected_characters(*this, m_current_input_path, m_skipped_reads);
+			m_delegate->found_total_reads_with_unexpected_characters(*this, m_input_path, m_skipped_reads);
 	}
 
 

--- a/libbio_reader_adapter.cpp
+++ b/libbio_reader_adapter.cpp
@@ -1,3 +1,5 @@
+#include "libbio_reader_adapter.hpp"
+
 #include <algorithm>
 #include <bit>
 #include <cstdint>
@@ -12,7 +14,7 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include "libbio_reader_adapter.hpp"
+
 #include "pack_characters.hpp"
 
 namespace lb = libbio;
@@ -20,225 +22,221 @@ namespace lb = libbio;
 
 namespace sf::detail {
 
-	constexpr inline unsigned char reverse_bits_8_32b(unsigned char cc)
-	{
-		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
-		return ((cc * UINT32_C(0x0802) & UINT32_C(0x22110)) | (cc * UINT32_C(0x8020) & UINT32_C(0x88440))) * UINT32_C(0x10101) >> 16U;
-	}
-
-
-	constexpr inline unsigned char reverse_bits_8_64b(unsigned char cc)
-	{
-		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
-		return ((cc * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101) >> 32U;
-	}
-
-
-	constexpr inline std::uint64_t reverse_bits_64b(std::uint64_t cc)
-	{
-		// First reverse the 4-byte words, then the 2-byte words, then
-		// bytes, nibbles, groups of 2 bits and finally single bits.
-		//
-		// For x86-64, Clang 21.1.0 produces 20 instructions (excluding ret)
-		// for the extern version of this function, GCC 15 a few more.
-		// (The first two swaps get replaced by something apparently more
-		// efficient.) For ARM, both compilers produce a single instruction,
-		// rbit.
-
-		cc = std::rotr(cc, 32);
-
-		{
-			auto const mask{UINT64_C(0x0000'FFFF'0000'FFFF)};
-			cc = ((mask & cc) << 16U) | ((~mask & cc) >> 16U);
-		}
-
-		{
-			auto const mask{UINT64_C(0x00FF'00FF'00FF'00FF)};
-			cc = ((mask & cc) << 8U) | ((~mask & cc) >> 8U);
-		}
-
-		{
-			auto const mask{UINT64_C(0x0F0F'0F0F'0F0F'0F0F)};
-			cc = ((mask & cc) << 4U) | ((~mask & cc) >> 4U);
-		}
-
-		{
-			auto const mask{UINT64_C(0x3333'3333'3333'3333)};
-			cc = ((mask & cc) << 2U) | ((~mask & cc) >> 2U);
-		}
-
-		{
-			auto const mask{UINT64_C(0x5555'5555'5555'5555)};
-			cc = ((mask & cc) << 1U) | ((~mask & cc) >> 1U);
-		}
-
-		return cc;
-	}
-
-
-	constexpr inline std::uint64_t reverse_bits_8x8b(std::uint64_t word)
-	{
-		// This requires way more instructions than reverse_bits_64b.
-
-		word = std::byteswap(word);
-
-		auto *bytes{reinterpret_cast <char *>(&word)};
-		bytes[0] = reverse_bits_8_64b(bytes[0]);
-		bytes[1] = reverse_bits_8_64b(bytes[1]);
-		bytes[2] = reverse_bits_8_64b(bytes[2]);
-		bytes[3] = reverse_bits_8_64b(bytes[3]);
-		bytes[4] = reverse_bits_8_64b(bytes[4]);
-		bytes[5] = reverse_bits_8_64b(bytes[5]);
-		bytes[6] = reverse_bits_8_64b(bytes[6]);
-		bytes[7] = reverse_bits_8_64b(bytes[7]);
-
-		return word;
-	}
-
-
-	constexpr inline std::uint64_t reverse_complement_packed(std::uint64_t word)
-	{
-		word = reverse_bits_64b(word);
-		word = ~word;
-		auto const b1{(word << 1U) & UINT64_C(0xAAAA'AAAA'AAAA'AAAA)};
-		auto const b2{(word >> 1U) & UINT64_C(0x5555'5555'5555'5555)};
-		word = b1 | b2;
-
-		return word;
-	}
-
-
-	void reverse_complement_packed_scalar_64b(std::span <std::uint64_t> packed_input, std::uint64_t const length)
-	{
-		if (0 == length)
-			return;
-
-		// Reverse the 8-byte words.
-		std::reverse(packed_input.begin(), packed_input.end());
-
-		auto const shift_right_amt{(length % 32U) * 2U};
-		auto const mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) >> shift_right_amt)}; // Avoid UB by replacing shift with rotate + bitwise and.
-		packed_input.front() = reverse_complement_packed(packed_input.front());
-		packed_input.front() = std::rotr(packed_input.front(), shift_right_amt) & mask;
-		for (std::size_t ii{1U}; ii < packed_input.size(); ++ii)
-		{
-			auto &word(packed_input[ii - 1]);
-			auto &next_word(packed_input[ii]);
-			next_word = reverse_complement_packed(next_word);
-			word |= next_word >> shift_right_amt;
-			next_word = std::rotr(next_word, shift_right_amt) & mask;
-		}
-	}
+constexpr inline unsigned char reverse_bits_8_32b(unsigned char cc) {
+                // From
+                // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
+  return ((cc * UINT32_C(0x0802) & UINT32_C(0x22110)) |
+          (cc * UINT32_C(0x8020) & UINT32_C(0x88440))) *
+             UINT32_C(0x10101) >>
+         16U;
 }
+
+
+constexpr inline unsigned char reverse_bits_8_64b(unsigned char cc) {
+                // From
+                // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
+  return ((cc * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) *
+             UINT64_C(0x0101010101) >>
+         32U;
+}
+
+
+constexpr inline std::uint64_t reverse_bits_64b(std::uint64_t cc) {
+                // First reverse the 4-byte words, then the 2-byte words, then
+                // bytes, nibbles, groups of 2 bits and finally single bits.
+                //
+                // For x86-64, Clang 21.1.0 produces 20 instructions (excluding ret)
+                // for the extern version of this function, GCC 15 a few more.
+                // (The first two swaps get replaced by something apparently more
+                // efficient.) For ARM, both compilers produce a single instruction,
+                // rbit.
+
+  cc = std::rotr(cc, 32);
+
+  {
+    auto const mask{UINT64_C(0x0000'FFFF'0000'FFFF)};
+    cc = ((mask & cc) << 16U) | ((~mask & cc) >> 16U);
+  }
+
+  {
+    auto const mask{UINT64_C(0x00FF'00FF'00FF'00FF)};
+    cc = ((mask & cc) << 8U) | ((~mask & cc) >> 8U);
+  }
+
+  {
+    auto const mask{UINT64_C(0x0F0F'0F0F'0F0F'0F0F)};
+    cc = ((mask & cc) << 4U) | ((~mask & cc) >> 4U);
+  }
+
+  {
+    auto const mask{UINT64_C(0x3333'3333'3333'3333)};
+    cc = ((mask & cc) << 2U) | ((~mask & cc) >> 2U);
+  }
+
+  {
+    auto const mask{UINT64_C(0x5555'5555'5555'5555)};
+    cc = ((mask & cc) << 1U) | ((~mask & cc) >> 1U);
+  }
+
+  return cc;
+}
+
+
+constexpr inline std::uint64_t reverse_bits_8x8b(std::uint64_t word) {
+                // This requires way more instructions than reverse_bits_64b.
+
+  word = std::byteswap(word);
+
+  auto* bytes{reinterpret_cast<char*>(&word)};
+  bytes[0] = reverse_bits_8_64b(bytes[0]);
+  bytes[1] = reverse_bits_8_64b(bytes[1]);
+  bytes[2] = reverse_bits_8_64b(bytes[2]);
+  bytes[3] = reverse_bits_8_64b(bytes[3]);
+  bytes[4] = reverse_bits_8_64b(bytes[4]);
+  bytes[5] = reverse_bits_8_64b(bytes[5]);
+  bytes[6] = reverse_bits_8_64b(bytes[6]);
+  bytes[7] = reverse_bits_8_64b(bytes[7]);
+
+  return word;
+}
+
+
+constexpr inline std::uint64_t reverse_complement_packed(std::uint64_t word) {
+  word = reverse_bits_64b(word);
+  word = ~word;
+  auto const b1{(word << 1U) & UINT64_C(0xAAAA'AAAA'AAAA'AAAA)};
+  auto const b2{(word >> 1U) & UINT64_C(0x5555'5555'5555'5555)};
+  word = b1 | b2;
+
+  return word;
+}
+
+
+void reverse_complement_packed_scalar_64b(std::span<std::uint64_t> packed_input,
+                                          std::uint64_t const length) {
+  if (0 == length) return;
+
+                // Reverse the 8-byte words.
+  std::reverse(packed_input.begin(), packed_input.end());
+
+  auto const shift_right_amt{(length % 32U) * 2U};
+  auto const mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) >>
+                    shift_right_amt)}; // Avoid UB by replacing shift with
+                                                                                        // rotate + bitwise and.
+  packed_input.front() = reverse_complement_packed(packed_input.front());
+  packed_input.front() =
+      std::rotr(packed_input.front(), shift_right_amt) & mask;
+  for (std::size_t ii{1U}; ii < packed_input.size(); ++ii) {
+    auto& word(packed_input[ii - 1]);
+    auto& next_word(packed_input[ii]);
+    next_word = reverse_complement_packed(next_word);
+    word |= next_word >> shift_right_amt;
+    next_word = std::rotr(next_word, shift_right_amt) & mask;
+  }
+}
+}  // namespace sf::detail
 
 
 namespace sf {
 
-	void libbio_reader_adapter::read_from_path(char const *path)
-	{
-		libbio_assert(m_delegate);
+void libbio_reader_adapter::read_from_path(char const* path) {
+  libbio_assert(m_delegate);
 
-		std::string_view path_{path};
+  std::string_view path_{path};
 
-		m_handle = lb::file_handle(lb::open_file_for_reading(path));
-		if (path_.ends_with(".gz"))
-		{
-			m_gzip_handle.set_gzip_input_handle(m_handle);
-			m_reading_handle = &m_gzip_handle;
-			path_.remove_suffix(3);
-		}
-		else
-		{
-			m_reading_handle = &m_handle;
-		}
+  m_handle = lb::file_handle(lb::open_file_for_reading(path));
+  if (path_.ends_with(".gz")) {
+    m_gzip_handle.set_gzip_input_handle(m_handle);
+    m_reading_handle = &m_gzip_handle;
+    path_.remove_suffix(3);
+  } else {
+    m_reading_handle = &m_handle;
+  }
 
-		if (path_.ends_with(".fasta") || path_.ends_with(".fa"))
-			m_reader = &m_fasta_reader;
-		else if (path_.ends_with(".fastq") || path_.ends_with(".fq"))
-			m_reader = &m_fastq_reader;
-		else
-		{
-			std::cerr << "FATAL: Unexpected suffix in path “" << path << "”.\n";
-			std::exit(1);
-		}
+  if (path_.ends_with(".fasta") || path_.ends_with(".fa"))
+    m_reader = &m_fasta_reader;
+  else if (path_.ends_with(".fastq") || path_.ends_with(".fq"))
+    m_reader = &m_fastq_reader;
+  else {
+    std::cerr << "FATAL: Unexpected suffix in path “" << path << "”.\n";
+    std::exit(1);
+  }
 
-		m_input_path = path_;
-		m_parsing_block_size = m_reading_handle->io_op_blocksize();
-		m_skipped_reads = 0;
-		m_should_report_errors = m_delegate->should_report_errors_for_path(*this, path_);
-		m_reader->prepare();
-	}
-
-
-	bool libbio_reader_adapter::retrieve_next_read()
-	{
-		if (m_next_read_is_reverse_complement)
-		{
-			m_next_read_is_reverse_complement = false;
-			detail::reverse_complement_packed_scalar_64b(std::span{m_read_buffer.data(), m_read_buffer.size()}, m_read_length);
-		}
-		else
-		{
-			m_next_read_is_reverse_complement = true;
-
-			while (true)
-			{
-				m_read_buffer.clear();
-				m_read_length = 0;
-				m_read_is_valid = true;
-
-				auto const status{m_reader->parse_(*m_reading_handle, m_parsing_block_size)};
-				if (lb::sequence_reader::parsing_status::failure == status || (0 == m_read_length && m_read_is_valid))
-				{
-					m_reading_handle->finish();
-					return false;
-				}
-
-				if (m_read_is_valid)
-					break;
-
-				// Reached if the current read is invalid. We report only the first error.
-				if (0 == m_skipped_reads && m_should_report_errors)
-					m_delegate->found_first_read_with_unexpected_character(*this, m_input_path, m_reader->line_number());
-				++m_skipped_reads;
-			}
-		}
-
-		return true;
-	}
-
-
-	void libbio_reader_adapter::finish()
-	{
-		if (m_skipped_reads && m_should_report_errors)
-			m_delegate->found_total_reads_with_unexpected_characters(*this, m_input_path, m_skipped_reads);
-	}
-
-
-	bool libbio_reader_adapter::handle_sequence_chunk(lb::fasta_reader_base &reader, std::string_view sv, bool has_newline)
-	{
-		if (m_read_is_valid) [[likely]]
-		{
-			auto const chunk_length{pack_characters(sv, m_read_buffer, m_read_length)};
-			m_read_is_valid = (UINT64_MAX != chunk_length);
-			if (m_read_is_valid) [[likely]]
-				m_read_length += chunk_length;
-		}
-
-		return true;
-	}
-
-
-	bool libbio_reader_adapter::handle_sequence_chunk(lb::fastq_reader_base &reader, std::string_view sv, bool has_newline)
-	{
-		if (m_read_is_valid) [[likely]]
-		{
-			auto const chunk_length{pack_characters(sv, m_read_buffer, m_read_length)};
-			m_read_is_valid = (UINT64_MAX != chunk_length);
-			if (m_read_is_valid) [[likely]]
-				m_read_length += chunk_length;
-		}
-
-		return true;
-	}
+  m_input_path = path_;
+  m_parsing_block_size = m_reading_handle->io_op_blocksize();
+  m_skipped_reads = 0;
+  m_should_report_errors =
+      m_delegate->should_report_errors_for_path(*this, path_);
+  m_reader->prepare();
 }
+
+
+bool libbio_reader_adapter::retrieve_next_read() {
+  if (m_next_read_is_reverse_complement) {
+    m_next_read_is_reverse_complement = false;
+    detail::reverse_complement_packed_scalar_64b(
+        std::span{m_read_buffer.data(), m_read_buffer.size()}, m_read_length);
+  } else {
+    m_next_read_is_reverse_complement = true;
+
+    while (true) {
+      m_read_buffer.clear();
+      m_read_length = 0;
+      m_read_is_valid = true;
+
+      auto const status{
+          m_reader->parse_(*m_reading_handle, m_parsing_block_size)};
+      if (lb::sequence_reader::parsing_status::failure == status ||
+          (0 == m_read_length && m_read_is_valid)) {
+        m_reading_handle->finish();
+        return false;
+      }
+
+      if (m_read_is_valid) break;
+
+      // Reached if the current read is invalid. We report only the first error.
+      if (0 == m_skipped_reads && m_should_report_errors)
+        m_delegate->found_first_read_with_unexpected_character(
+            *this, m_input_path, m_reader->line_number());
+      ++m_skipped_reads;
+    }
+  }
+
+  return true;
+}
+
+
+void libbio_reader_adapter::finish() {
+  if (m_skipped_reads && m_should_report_errors)
+    m_delegate->found_total_reads_with_unexpected_characters(
+        *this, m_input_path, m_skipped_reads);
+}
+
+
+bool libbio_reader_adapter::handle_sequence_chunk(lb::fasta_reader_base& reader,
+                                                  std::string_view sv,
+                                                  bool has_newline) {
+  if (m_read_is_valid) [[likely]] {
+    auto const chunk_length{pack_characters(sv, m_read_buffer, m_read_length)};
+    m_read_is_valid = (UINT64_MAX != chunk_length);
+    if (m_read_is_valid) [[likely]]
+      m_read_length += chunk_length;
+  }
+
+  return true;
+}
+
+
+bool libbio_reader_adapter::handle_sequence_chunk(lb::fastq_reader_base& reader,
+                                                  std::string_view sv,
+                                                  bool has_newline) {
+  if (m_read_is_valid) [[likely]] {
+    auto const chunk_length{pack_characters(sv, m_read_buffer, m_read_length)};
+    m_read_is_valid = (UINT64_MAX != chunk_length);
+    if (m_read_is_valid) [[likely]]
+      m_read_length += chunk_length;
+  }
+
+  return true;
+}
+}  // namespace sf

--- a/libbio_reader_adapter.cpp
+++ b/libbio_reader_adapter.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <libbio/assert.hh>
 #include <libbio/fasta_reader.hh>
 #include <libbio/fastq_reader.hh>
 #include <libbio/file_handle.hh>
@@ -18,6 +19,32 @@ namespace lb = libbio;
 
 
 namespace {
+
+	void print_read(std::span <std::uint64_t const> span, std::uint64_t len)
+	{
+		std::cerr << "** read: ";
+		for (auto word : span)
+		{
+			for (std::uint8_t ii{}; ii < 32U; ++ii)
+			{
+				word = std::rotl(word, 2);
+				auto const cc{word & 0x3};
+				switch (cc)
+				{
+					case 0: std::cerr << 'A'; break;
+					case 1: std::cerr << 'C'; break;
+					case 2: std::cerr << 'G'; break;
+					case 3: std::cerr << 'T'; break;
+					default: std::abort();
+				}
+
+				--len;
+				if (0 == len)
+					break;
+			}
+		}
+		std::cerr << '\n';
+	}
 
 	std::uint64_t read_into_packed_sequence(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos)
 	{
@@ -99,17 +126,91 @@ namespace {
 
 namespace sf::detail {
 
-	constexpr inline unsigned char reverse_bits_32b(unsigned char cc)
+	constexpr inline unsigned char reverse_bits_8_32b(unsigned char cc)
 	{
 		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
 		return ((cc * UINT32_C(0x0802) & UINT32_C(0x22110)) | (cc * UINT32_C(0x8020) & UINT32_C(0x88440))) * UINT32_C(0x10101) >> 16U;
 	}
 
 
-	constexpr inline unsigned char reverse_bits_64b(unsigned char cc)
+	constexpr inline unsigned char reverse_bits_8_64b(unsigned char cc)
 	{
 		// From https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
-		return  ((cc * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101) >> 32U;
+		return ((cc * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101) >> 32U;
+	}
+
+
+	constexpr inline std::uint64_t reverse_bits_64b(std::uint64_t cc)
+	{
+		// First reverse the 4-byte words, then the 2-byte words, then
+		// bytes, nibbles, groups of 2 bits and finally single bits.
+		//
+		// For x86-64, Clang 21.1.0 produces 20 instructions (excluding ret)
+		// for the extern version of this function, GCC 15 a few more.
+		// (The first two swaps get replaced by something apparently more
+		// efficient.) For ARM, both compilers produce a single instruction,
+		// rbit.
+
+		cc = std::rotr(cc, 32);
+
+		{
+			auto const mask{UINT64_C(0x0000'FFFF'0000'FFFF)};
+			cc = ((mask & cc) << 16U) | ((~mask & cc) >> 16U);
+		}
+
+		{
+			auto const mask{UINT64_C(0x00FF'00FF'00FF'00FF)};
+			cc = ((mask & cc) << 8U) | ((~mask & cc) >> 8U);
+		}
+
+		{
+			auto const mask{UINT64_C(0x0F0F'0F0F'0F0F'0F0F)};
+			cc = ((mask & cc) << 4U) | ((~mask & cc) >> 4U);
+		}
+
+		{
+			auto const mask{UINT64_C(0x3333'3333'3333'3333)};
+			cc = ((mask & cc) << 2U) | ((~mask & cc) >> 2U);
+		}
+
+		{
+			auto const mask{UINT64_C(0x5555'5555'5555'5555)};
+			cc = ((mask & cc) << 1U) | ((~mask & cc) >> 1U);
+		}
+
+		return cc;
+	}
+
+
+	constexpr inline std::uint64_t reverse_bits_8x8b(std::uint64_t word)
+	{
+		// This requires way more instructions than reverse_bits_64b.
+
+		word = std::byteswap(word);
+
+		auto *bytes{reinterpret_cast <char *>(&word)};
+		bytes[0] = reverse_bits_8_64b(bytes[0]);
+		bytes[1] = reverse_bits_8_64b(bytes[1]);
+		bytes[2] = reverse_bits_8_64b(bytes[2]);
+		bytes[3] = reverse_bits_8_64b(bytes[3]);
+		bytes[4] = reverse_bits_8_64b(bytes[4]);
+		bytes[5] = reverse_bits_8_64b(bytes[5]);
+		bytes[6] = reverse_bits_8_64b(bytes[6]);
+		bytes[7] = reverse_bits_8_64b(bytes[7]);
+
+		return word;
+	}
+
+
+	constexpr inline std::uint64_t reverse_complement_packed(std::uint64_t word)
+	{
+		word = reverse_bits_64b(word);
+		word = ~word;
+		auto const b1{(word << 1U) & UINT64_C(0xAAAA'AAAA'AAAA'AAAA)};
+		auto const b2{(word >> 1U) & UINT64_C(0x5555'5555'5555'5555)};
+		word = b1 | b2;
+
+		return word;
 	}
 
 
@@ -119,34 +220,17 @@ namespace sf::detail {
 			return;
 
 		// Reverse the 8-byte words.
-		std::reverse(packed_input.begin(), packed_input.end() - 1);
-
-		auto const reverse_complement([](std::uint64_t word){
-			word = std::byteswap(word);
-
-			auto *bytes{reinterpret_cast <char *>(&word)};
-			bytes[0] = reverse_bits_64b(bytes[0]);
-			bytes[1] = reverse_bits_64b(bytes[1]);
-			bytes[2] = reverse_bits_64b(bytes[2]);
-			bytes[3] = reverse_bits_64b(bytes[3]);
-
-			word = ~word;
-			auto const b1{(word << 1U) & UINT64_C(0xAAAA'AAAA'AAAA'AAAA)};
-			auto const b2{(word >> 1U) & UINT64_C(0x5555'5555'5555'5555)};
-			word = b1 | b2;
-
-			return word;
-		});
+		std::reverse(packed_input.begin(), packed_input.end());
 
 		auto const shift_right_amt{(length % 32U) * 2U};
 		auto const mask{~(UINT64_C(0xFFFF'FFFF'FFFF'FFFF) >> shift_right_amt)}; // Avoid UB by replacing shift with rotate + bitwise and.
-		packed_input.front() = reverse_complement(packed_input.front());
-		packed_input.front() = std::rotr(packed_input.front(), shift_right_amt);
-		for (std::size_t ii{1U}; ii < packed_input.size() - 1; ++ii)
+		packed_input.front() = reverse_complement_packed(packed_input.front());
+		packed_input.front() = std::rotr(packed_input.front(), shift_right_amt) & mask;
+		for (std::size_t ii{1U}; ii < packed_input.size(); ++ii)
 		{
 			auto &word(packed_input[ii - 1]);
 			auto &next_word(packed_input[ii]);
-			next_word = reverse_complement(next_word);
+			next_word = reverse_complement_packed(next_word);
 			word |= next_word >> shift_right_amt;
 			next_word = std::rotr(next_word, shift_right_amt) & mask;
 		}
@@ -158,6 +242,8 @@ namespace sf {
 
 	void libbio_reader_adapter::read_from_path(char const *path)
 	{
+		libbio_assert(m_delegate);
+
 		std::string_view path_{path};
 
 		m_handle = lb::file_handle(lb::open_file_for_reading(path));
@@ -182,6 +268,10 @@ namespace sf {
 			std::exit(1);
 		}
 
+		m_current_input_path = path_;
+		m_parsing_block_size = m_reading_handle->io_op_blocksize();
+		m_skipped_reads = 0;
+		m_should_report_errors = m_delegate->should_report_errors_for_path(*this, path_);
 		m_reader->prepare();
 	}
 
@@ -203,8 +293,8 @@ namespace sf {
 				m_read_length = 0;
 				m_read_is_valid = true;
 
-				auto const status{m_reader->parse_(*m_reading_handle)};
-				if (lb::sequence_reader::parsing_status::failure == status || 0 == m_read_length)
+				auto const status{m_reader->parse_(*m_reading_handle, m_parsing_block_size)};
+				if (lb::sequence_reader::parsing_status::failure == status || (0 == m_read_length && m_read_is_valid))
 				{
 					m_reading_handle->finish();
 					return false;
@@ -213,36 +303,49 @@ namespace sf {
 				if (m_read_is_valid)
 					break;
 
-				std::cerr << "Skipping read on line "  << m_reader->line_number() << " due to unexpected character.\n";
+				// Reached if the current read is invalid. We report only the first error.
+				if (0 == m_skipped_reads && m_should_report_errors)
+					std::cerr << "WARNING: Skipping reads with unexpected characters in " << m_current_input_path << "; first one on line " << m_reader->line_number() << ".\n";
+				++m_skipped_reads;
 			}
+		}
+
+		//print_read(std::span{m_read_buffer.data(), m_read_buffer.size()}, m_read_length);
+		return true;
+	}
+
+
+	void libbio_reader_adapter::finish()
+	{
+		if (m_skipped_reads && m_should_report_errors)
+			m_delegate->found_total_reads_with_unexpected_characters(*this, m_current_input_path, m_skipped_reads);
+	}
+
+
+	bool libbio_reader_adapter::handle_sequence_chunk(lb::fasta_reader_base &reader, std::string_view sv, bool has_newline)
+	{
+		if (m_read_is_valid) [[likely]]
+		{
+			auto const chunk_length{read_into_packed_sequence(sv, m_read_buffer, m_read_length)};
+			m_read_is_valid = (UINT64_MAX != chunk_length);
+			if (m_read_is_valid) [[likely]]
+				m_read_length += chunk_length;
 		}
 
 		return true;
 	}
 
 
-	bool libbio_reader_adapter::handle_sequence_chunk(lb::fasta_reader_base &reader, std::string_view sv, bool has_newline)
-	{
-		m_read_length = read_into_packed_sequence(sv, m_read_buffer, m_read_length);
-		return (UINT64_MAX != m_read_length);
-	}
-
-
 	bool libbio_reader_adapter::handle_sequence_chunk(lb::fastq_reader_base &reader, std::string_view sv, bool has_newline)
 	{
-		m_read_length = read_into_packed_sequence(sv, m_read_buffer, m_read_length);
-		return (UINT64_MAX != m_read_length);
-	}
+		if (m_read_is_valid) [[likely]]
+		{
+			auto const chunk_length{read_into_packed_sequence(sv, m_read_buffer, m_read_length)};
+			m_read_is_valid = (UINT64_MAX != chunk_length);
+			if (m_read_is_valid) [[likely]]
+				m_read_length += chunk_length;
+		}
 
-
-	bool libbio_reader_adapter::handle_sequence_end(lb::fasta_reader_base &reader)
-	{
-		return false;
-	}
-
-
-	bool libbio_reader_adapter::handle_sequence_end(lb::fastq_reader_base &reader)
-	{
-		return false;
+		return true;
 	}
 }

--- a/pack_characters.cpp
+++ b/pack_characters.cpp
@@ -10,144 +10,146 @@
 
 namespace sf {
 
-	void print_read(std::span <std::uint64_t const> span, std::uint64_t len)
-	{
-		std::cerr << "** read: ";
-		for (auto word : span)
-		{
-			for (std::uint8_t ii{}; ii < 32U; ++ii)
-			{
-				word = std::rotl(word, 2);
-				auto const cc{word & 0x3};
-				switch (cc)
-				{
-					case 0: std::cerr << 'A'; break;
-					case 1: std::cerr << 'C'; break;
-					case 2: std::cerr << 'G'; break;
-					case 3: std::cerr << 'T'; break;
-					default: throw std::runtime_error("Unexpected character");
-				}
+void print_read(std::span<std::uint64_t const> span, std::uint64_t len) {
+  std::cerr << "** read: ";
+  for (auto word : span) {
+    for (std::uint8_t ii{}; ii < 32U; ++ii) {
+      word = std::rotl(word, 2);
+      auto const cc{word & 0x3};
+      switch (cc) {
+        case 0:
+          std::cerr << 'A';
+          break;
+        case 1:
+          std::cerr << 'C';
+          break;
+        case 2:
+          std::cerr << 'G';
+          break;
+        case 3:
+          std::cerr << 'T';
+          break;
+        default:
+          throw std::runtime_error("Unexpected character");
+      }
 
-				--len;
-				if (0 == len)
-					break;
-			}
-		}
-		std::cerr << '\n';
-	}
-
-
-	std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos)
-	{
-		auto const push_packed([](char const cc, std::uint64_t &dst_word, std::uint64_t const dst_pos_) -> bool {
-			auto const chararcter_pos{dst_pos_ % 32U};
-			std::uint64_t const shift_amt{62U - 2 * chararcter_pos};
-			switch (cc)
-			{
-				case 'A':
-				case 'a':
-					break;
-
-				case 'C':
-				case 'c':
-					dst_word |= UINT64_C(0x1) << shift_amt;
-					break;
-
-				case 'G':
-				case 'g':
-					dst_word |= UINT64_C(0x2) << shift_amt;
-					break;
-
-				case 'T':
-				case 't':
-					dst_word |= UINT64_C(0x3) << shift_amt;
-					break;
-
-				[[unlikely]] default:
-					return false;
-			}
-
-			return true;
-		});
-
-		auto it{sv.cbegin()};
-		auto const end{sv.cend()};
-
-		// If the current position is not divisible by 32, dst
-		// must be non-empty.
-		if (dst_pos % 32U)
-		{
-			auto &dst_word{dst.back()};
-			do
-			{
-				if (it == end)
-					return dst_pos;
-
-				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
-					return UINT64_MAX;
-
-				++dst_pos;
-				++it;
-			} while (dst_pos % 32U);
-		}
-
-		if (it == end)
-			return dst_pos;
-
-		// 0 == dst_pos % 32U.
-		while (true)
-		{
-			auto &dst_word{dst.emplace_back(0)};
-			do
-			{
-				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
-					return UINT64_MAX;
-
-				++dst_pos;
-				++it;
-
-				if (it == end)
-					return dst_pos;
-			} while (dst_pos % 32U);
-
-			if (it == end)
-				return dst_pos;
-		}
-	}
-
-
-	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst)
-	{
-		auto const append_character([&dst](std::uint64_t const word){
-			switch (word & UINT64_C(0x3))
-			{
-				case 0x0: dst.push_back('A'); break;
-				case 0x1: dst.push_back('C'); break;
-				case 0x2: dst.push_back('G'); break;
-				case 0x3: dst.push_back('T'); break;
-				default: throw std::runtime_error("Unexpected value");
-			}
-		});
-
-		std::uint64_t ii{};
-		while (ii + 32 <= length)
-		{
-			auto word{src[ii / 32]};
-			for (std::uint8_t jj{}; jj < 32; ++jj)
-			{
-				word = std::rotl(word, 2);
-				append_character(word);
-			}
-
-			ii += 32;
-		}
-
-		auto word{src[ii / 32]};
-		while (ii < length)
-		{
-			word = std::rotl(word, 2);
-			append_character(word);
-			++ii;
-		}
-	}
+      --len;
+      if (0 == len) break;
+    }
+  }
+  std::cerr << '\n';
 }
+
+
+std::uint64_t pack_characters(std::string_view sv,
+                              std::vector<std::uint64_t>& dst,
+                              std::uint64_t dst_pos) {
+  auto const push_packed([](char const cc, std::uint64_t& dst_word,
+                            std::uint64_t const dst_pos_) -> bool {
+    auto const chararcter_pos{dst_pos_ % 32U};
+    std::uint64_t const shift_amt{62U - 2 * chararcter_pos};
+    switch (cc) {
+      case 'A':
+      case 'a':
+        break;
+
+      case 'C':
+      case 'c':
+        dst_word |= UINT64_C(0x1) << shift_amt;
+        break;
+
+      case 'G':
+      case 'g':
+        dst_word |= UINT64_C(0x2) << shift_amt;
+        break;
+
+      case 'T':
+      case 't':
+        dst_word |= UINT64_C(0x3) << shift_amt;
+        break;
+
+      [[unlikely]] default:
+        return false;
+    }
+
+    return true;
+  });
+
+  auto it{sv.cbegin()};
+  auto const end{sv.cend()};
+
+                // If the current position is not divisible by 32, dst
+                // must be non-empty.
+  if (dst_pos % 32U) {
+    auto& dst_word{dst.back()};
+    do {
+      if (it == end) return dst_pos;
+
+      if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+        return UINT64_MAX;
+
+      ++dst_pos;
+      ++it;
+    } while (dst_pos % 32U);
+  }
+
+  if (it == end) return dst_pos;
+
+                // 0 == dst_pos % 32U.
+  while (true) {
+    auto& dst_word{dst.emplace_back(0)};
+    do {
+      if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+        return UINT64_MAX;
+
+      ++dst_pos;
+      ++it;
+
+      if (it == end) return dst_pos;
+    } while (dst_pos % 32U);
+
+    if (it == end) return dst_pos;
+  }
+}
+
+
+void unpack_characters(std::vector<std::uint64_t> const& src,
+                       std::uint64_t length, std::string& dst) {
+  auto const append_character([&dst](std::uint64_t const word) {
+    switch (word & UINT64_C(0x3)) {
+      case 0x0:
+        dst.push_back('A');
+        break;
+      case 0x1:
+        dst.push_back('C');
+        break;
+      case 0x2:
+        dst.push_back('G');
+        break;
+      case 0x3:
+        dst.push_back('T');
+        break;
+      default:
+        throw std::runtime_error("Unexpected value");
+    }
+  });
+
+  std::uint64_t ii{};
+  while (ii + 32 <= length) {
+    auto word{src[ii / 32]};
+    for (std::uint8_t jj{}; jj < 32; ++jj) {
+      word = std::rotl(word, 2);
+      append_character(word);
+    }
+
+    ii += 32;
+  }
+
+  auto word{src[ii / 32]};
+  while (ii < length) {
+    word = std::rotl(word, 2);
+    append_character(word);
+    ++ii;
+  }
+}
+}  // namespace sf

--- a/pack_characters.cpp
+++ b/pack_characters.cpp
@@ -1,0 +1,153 @@
+#include <bit>
+#include <cstdint>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+
+namespace sf {
+
+	void print_read(std::span <std::uint64_t const> span, std::uint64_t len)
+	{
+		std::cerr << "** read: ";
+		for (auto word : span)
+		{
+			for (std::uint8_t ii{}; ii < 32U; ++ii)
+			{
+				word = std::rotl(word, 2);
+				auto const cc{word & 0x3};
+				switch (cc)
+				{
+					case 0: std::cerr << 'A'; break;
+					case 1: std::cerr << 'C'; break;
+					case 2: std::cerr << 'G'; break;
+					case 3: std::cerr << 'T'; break;
+					default: throw std::runtime_error("Unexpected character");
+				}
+
+				--len;
+				if (0 == len)
+					break;
+			}
+		}
+		std::cerr << '\n';
+	}
+
+
+	std::uint64_t pack_characters(std::string_view sv, std::vector <std::uint64_t> &dst, std::uint64_t dst_pos)
+	{
+		auto const push_packed([](char const cc, std::uint64_t &dst_word, std::uint64_t const dst_pos_) -> bool {
+			auto const chararcter_pos{dst_pos_ % 32U};
+			std::uint64_t const shift_amt{62U - 2 * chararcter_pos};
+			switch (cc)
+			{
+				case 'A':
+				case 'a':
+					break;
+
+				case 'C':
+				case 'c':
+					dst_word |= UINT64_C(0x1) << shift_amt;
+					break;
+
+				case 'G':
+				case 'g':
+					dst_word |= UINT64_C(0x2) << shift_amt;
+					break;
+
+				case 'T':
+				case 't':
+					dst_word |= UINT64_C(0x3) << shift_amt;
+					break;
+
+				[[unlikely]] default:
+					return false;
+			}
+
+			return true;
+		});
+
+		auto it{sv.cbegin()};
+		auto const end{sv.cend()};
+
+		// If the current position is not divisible by 32, dst
+		// must be non-empty.
+		if (dst_pos % 32U)
+		{
+			auto &dst_word{dst.back()};
+			do
+			{
+				if (it == end)
+					return dst_pos;
+
+				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+					return UINT64_MAX;
+
+				++dst_pos;
+				++it;
+			} while (dst_pos % 32U);
+		}
+
+		if (it == end)
+			return dst_pos;
+
+		// 0 == dst_pos % 32U.
+		while (true)
+		{
+			auto &dst_word{dst.emplace_back(0)};
+			do
+			{
+				if (!push_packed(*it, dst_word, dst_pos)) [[unlikely]]
+					return UINT64_MAX;
+
+				++dst_pos;
+				++it;
+
+				if (it == end)
+					return dst_pos;
+			} while (dst_pos % 32U);
+
+			if (it == end)
+				return dst_pos;
+		}
+	}
+
+
+	void unpack_characters(std::vector <std::uint64_t> const &src, std::uint64_t length, std::string &dst)
+	{
+		auto const append_character([&dst](std::uint64_t const word){
+			switch (word & UINT64_C(0x3))
+			{
+				case 0x0: dst.push_back('A'); break;
+				case 0x1: dst.push_back('C'); break;
+				case 0x2: dst.push_back('G'); break;
+				case 0x3: dst.push_back('T'); break;
+				default: throw std::runtime_error("Unexpected value");
+			}
+		});
+
+		std::uint64_t ii{};
+		while (ii + 32 <= length)
+		{
+			auto word{src[ii / 32]};
+			for (std::uint8_t jj{}; jj < 32; ++jj)
+			{
+				word = std::rotl(word, 2);
+				append_character(word);
+			}
+
+			ii += 32;
+		}
+
+		auto word{src[ii / 32]};
+		while (ii < length)
+		{
+			word = std::rotl(word, 2);
+			append_character(word);
+			++ii;
+		}
+	}
+}

--- a/seed_finder.cpp
+++ b/seed_finder.cpp
@@ -69,7 +69,18 @@ void filter_seeds(auto& seeds, auto callback) {
   std::cerr << discarded_seeds << " seeds discarded in filtering" << std::endl;
 }
 
+
+void print_invocation(int argc, char const *argv[])
+{
+	std::cerr << "Invocation:";
+	for (int i{}; i < argc; ++i)
+		std::cerr << ' ' << argv[i];
+	std::cerr << '\n';
+}
+
+
 int main(int argc, char const* argv[]) {
+  print_invocation(argc, argv);
   std::string bg_path = "";
   std::string sig_path = "";
   std::string prefix = "";
@@ -283,7 +294,7 @@ int main(int argc, char const* argv[]) {
       finder.find_seeds();
       if (dot_output.size() > 0) {
         sf::Dot_Writer::write_dot<decltype(finder.get_seeds()),
-                                  decltype(finder)::G>(
+                                  decltype(finder)::gapmer_type>(
             dot_output, finder.get_seeds(), max_k);
       }
       sf::seed_clusterer<true, max_gap, decltype(finder.get_seeds())> sc(
@@ -304,7 +315,7 @@ int main(int argc, char const* argv[]) {
       finder.find_seeds();
       if (dot_output.size() > 0) {
         sf::Dot_Writer::write_dot<decltype(finder.get_seeds()),
-                                  decltype(finder)::G>(
+                                  decltype(finder)::gapmer_type>(
             dot_output, finder.get_seeds(), max_k);
       }
       sf::seed_clusterer<false, max_gap, decltype(finder.get_seeds())> sc(
@@ -327,7 +338,7 @@ int main(int argc, char const* argv[]) {
       finder.find_seeds();
       if (dot_output.size() > 0) {
         sf::Dot_Writer::write_dot<decltype(finder.get_seeds()),
-                                  decltype(finder)::G>(
+                                  decltype(finder)::gapmer_type>(
             dot_output, finder.get_seeds(), max_k);
       }
       sf::seed_clusterer<true, max_gap, decltype(finder.get_seeds())> sc(
@@ -348,7 +359,7 @@ int main(int argc, char const* argv[]) {
       finder.find_seeds();
       if (dot_output.size() > 0) {
         sf::Dot_Writer::write_dot<decltype(finder.get_seeds()),
-                                  decltype(finder)::G>(
+                                  decltype(finder)::gapmer_type>(
             dot_output, finder.get_seeds(), max_k);
       }
       sf::seed_clusterer<false, max_gap, decltype(finder.get_seeds())> sc(

--- a/seqio_reader_adapter.cpp
+++ b/seqio_reader_adapter.cpp
@@ -1,0 +1,52 @@
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <SeqIO/SeqIO.hh>
+#include "pack_characters.hpp"
+#include "seqio_reader_adapter.hpp"
+
+
+namespace sf {
+
+	void seqio_reader_adapter::read_from_path(char const *path)
+	{
+		m_reader = std::make_unique <seq_io::Reader_x>(path); // Moving not possible.
+		m_reader->enable_reverse_complements();
+		m_input_path = path;
+		m_should_report_errors = m_delegate->should_report_errors_for_path(*this, m_input_path);
+	}
+
+
+	bool seqio_reader_adapter::retrieve_next_read()
+	{
+		while (true)
+		{
+			auto const len{m_reader->get_next_read_to_buffer()};
+			assert(0 <= len);
+			m_read_length = len;
+
+			if (0 == read_length())
+				return false;
+
+			m_read_buffer.clear();
+			auto const res{pack_characters(m_reader->read_buf, m_read_buffer, 0)};
+
+			if (UINT64_MAX != res)
+				return true;
+
+			// Reached if the current read is invalid. We report only the first error.
+			if (0 == m_skipped_reads && m_should_report_errors)
+				m_delegate->found_first_read_with_unexpected_character(*this, m_input_path, 0); // No line number information available.
+			++m_skipped_reads;
+		}
+	}
+
+
+	void seqio_reader_adapter::finish()
+	{
+		if (m_skipped_reads && m_should_report_errors)
+			m_delegate->found_total_reads_with_unexpected_characters(*this, m_input_path, m_skipped_reads);
+
+		m_reader.reset();
+	}
+}

--- a/seqio_reader_adapter.cpp
+++ b/seqio_reader_adapter.cpp
@@ -1,52 +1,51 @@
+#include "seqio_reader_adapter.hpp"
+
+#include <SeqIO/SeqIO.hh>
 #include <cassert>
 #include <cstdint>
 #include <memory>
-#include <SeqIO/SeqIO.hh>
+
 #include "pack_characters.hpp"
-#include "seqio_reader_adapter.hpp"
 
 
 namespace sf {
 
-	void seqio_reader_adapter::read_from_path(char const *path)
-	{
-		m_reader = std::make_unique <seq_io::Reader_x>(path); // Moving not possible.
-		m_reader->enable_reverse_complements();
-		m_input_path = path;
-		m_should_report_errors = m_delegate->should_report_errors_for_path(*this, m_input_path);
-	}
-
-
-	bool seqio_reader_adapter::retrieve_next_read()
-	{
-		while (true)
-		{
-			auto const len{m_reader->get_next_read_to_buffer()};
-			assert(0 <= len);
-			m_read_length = len;
-
-			if (0 == read_length())
-				return false;
-
-			m_read_buffer.clear();
-			auto const res{pack_characters(m_reader->read_buf, m_read_buffer, 0)};
-
-			if (UINT64_MAX != res)
-				return true;
-
-			// Reached if the current read is invalid. We report only the first error.
-			if (0 == m_skipped_reads && m_should_report_errors)
-				m_delegate->found_first_read_with_unexpected_character(*this, m_input_path, 0); // No line number information available.
-			++m_skipped_reads;
-		}
-	}
-
-
-	void seqio_reader_adapter::finish()
-	{
-		if (m_skipped_reads && m_should_report_errors)
-			m_delegate->found_total_reads_with_unexpected_characters(*this, m_input_path, m_skipped_reads);
-
-		m_reader.reset();
-	}
+void seqio_reader_adapter::read_from_path(char const* path) {
+  m_reader = std::make_unique<seq_io::Reader_x>(path);  // Moving not possible.
+  m_reader->enable_reverse_complements();
+  m_input_path = path;
+  m_should_report_errors =
+      m_delegate->should_report_errors_for_path(*this, m_input_path);
 }
+
+
+bool seqio_reader_adapter::retrieve_next_read() {
+  while (true) {
+    auto const len{m_reader->get_next_read_to_buffer()};
+    assert(0 <= len);
+    m_read_length = len;
+
+    if (0 == read_length()) return false;
+
+    m_read_buffer.clear();
+    auto const res{pack_characters(m_reader->read_buf, m_read_buffer, 0)};
+
+    if (UINT64_MAX != res) return true;
+
+    // Reached if the current read is invalid. We report only the first error.
+    if (0 == m_skipped_reads && m_should_report_errors)
+      m_delegate->found_first_read_with_unexpected_character(
+          *this, m_input_path, 0);  // No line number information available.
+    ++m_skipped_reads;
+  }
+}
+
+
+void seqio_reader_adapter::finish() {
+  if (m_skipped_reads && m_should_report_errors)
+    m_delegate->found_total_reads_with_unexpected_characters(
+        *this, m_input_path, m_skipped_reads);
+
+  m_reader.reset();
+}
+}  // namespace sf

--- a/test/gapmer_arbitrary.hpp
+++ b/test/gapmer_arbitrary.hpp
@@ -1035,7 +1035,7 @@ RC_GTEST_PROP(gapmer_arbitrary, FromPackedCharacterStringConstructor,
   typedef std::vector<std::uint64_t> vector_type;
   // Non-zero length required in gapmer’s constructor.
   vector_type plain_text(1 + (test_input.text.size() + 7) / 8, 0);
-  vector_type packed_text(1 + (test_input.text.size() + 31) / 32, 0);
+  vector_type packed_text{};
   std::span plain_text_(reinterpret_cast<char*>(plain_text.data()),
                         test_input.text.size());
 

--- a/test/gapmer_arbitrary.hpp
+++ b/test/gapmer_arbitrary.hpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <span>
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -27,6 +28,7 @@
 #include "../include/util.hpp"
 #include "gtest/gtest.h"
 #include "nucleotide.hpp"
+#include "pack_characters.hpp"
 #include "test.hpp"
 
 
@@ -60,7 +62,7 @@ using pointer_to_data_member_t =
 
 
 struct gapmer_packed_input {
-  typedef std::vector <packed_nucleotide> text_type;
+  typedef std::vector<packed_nucleotide> text_type;
   text_type text;
   std::uint8_t kk{};
   std::uint8_t gap_start{};
@@ -68,29 +70,25 @@ struct gapmer_packed_input {
 
   constexpr gapmer_packed_input() = default;
 
-  explicit gapmer_packed_input(text_type const &text_, std::uint8_t kk_, std::uint8_t gap_start_, std::uint8_t gap_length_):
-  	text{text_},
-    kk{kk_},
-    gap_start{gap_start_},
-    gap_length{gap_length_}
-  {
-  RC_ASSERT((gap_start == 0 && gap_length == 0) || !(gap_start == 0 || gap_length == 0));
+  explicit gapmer_packed_input(text_type const& text_, std::uint8_t kk_,
+                               std::uint8_t gap_start_,
+                               std::uint8_t gap_length_)
+      : text{text_}, kk{kk_}, gap_start{gap_start_}, gap_length{gap_length_} {
+    RC_ASSERT((gap_start == 0 && gap_length == 0) ||
+              !(gap_start == 0 || gap_length == 0));
   }
 
-  explicit gapmer_packed_input(text_type const &text_, std::uint8_t kk_):
-    gapmer_packed_input(text_, kk_, 0, 0)
-  {
-  }
+  explicit gapmer_packed_input(text_type const& text_, std::uint8_t kk_)
+      : gapmer_packed_input(text_, kk_, 0, 0) {}
 };
 
 
-std::ostream &operator<<(std::ostream &os, gapmer_packed_input const &input)
-{
-	os << "text: ";
-	for (auto const cc : input.text)
-		os << char(cc);
-	os << " kk: " << +input.kk << " gap_start " << +input.gap_start << " gap_length: " << +input.gap_length;
-	return os;
+std::ostream& operator<<(std::ostream& os, gapmer_packed_input const& input) {
+  os << "text: ";
+  for (auto const cc : input.text) os << char(cc);
+  os << " kk: " << +input.kk << " gap_start " << +input.gap_start
+     << " gap_length: " << +input.gap_length;
+  return os;
 }
 
 
@@ -102,12 +100,12 @@ struct gapmer_data_config_base {
 };
 
 
-template <typename t_type, t_type gapmer_data_config_base::*t_member>
+template <typename t_type, t_type gapmer_data_config_base::* t_member>
 struct gapmer_data_constraint_tpl {
   t_type value{};
 
   constexpr gapmer_data_constraint_tpl(t_type value_) : value{value_} {};
-  constexpr void assign(gapmer_data_config_base &config) const {
+  constexpr void assign(gapmer_data_config_base& config) const {
     config.*t_member = value;
   }
 };
@@ -154,7 +152,7 @@ struct gapmer_data {
 
   gapmer_type to_gapmer() const;
   operator gapmer_type() const { return to_gapmer(); }
-  void write_to_buffer(std::vector<uint64_t> &buffer) const;
+  void write_to_buffer(std::vector<uint64_t>& buffer) const;
   uint8_t gap_start() const {
     return suffix_length ? length - suffix_length : 0;
   }
@@ -244,11 +242,11 @@ auto gapmer_data<t_gapmer>::to_gapmer() const -> gapmer_type {
 
 template <typename t_gapmer>
 void gapmer_data<t_gapmer>::write_to_buffer(
-    std::vector<uint64_t> &buffer) const {
+    std::vector<uint64_t>& buffer) const {
   if (!length) return;
 
   buffer.resize((length + gap_length - 1) / 8 + 1, 0);
-  auto *dst(reinterpret_cast<char *>(buffer.data()));
+  auto* dst(reinterpret_cast<char*>(buffer.data()));
   auto sequence_{std::rotr(sequence, 2 * (length - 1))};
   uint8_t i{};
 
@@ -272,7 +270,7 @@ void gapmer_data<t_gapmer>::write_to_buffer(
 
 
 template <typename t_gapmer>
-std::ostream &operator<<(std::ostream &os, gapmer_data<t_gapmer> const gd) {
+std::ostream& operator<<(std::ostream& os, gapmer_data<t_gapmer> const gd) {
   os << gd.to_gapmer().to_string() << " (" << +gd.length << ", "
      << +gd.gap_start() << ", " << +gd.gap_length << ')';
   return os;
@@ -280,15 +278,15 @@ std::ostream &operator<<(std::ostream &os, gapmer_data<t_gapmer> const gd) {
 
 
 template <typename t_gapmer>
-std::ostream &operator<<(std::ostream &os, gapmer_pair<t_gapmer> const &pp) {
+std::ostream& operator<<(std::ostream& os, gapmer_pair<t_gapmer> const& pp) {
   os << "source: " << pp.source << " target: " << pp.target;
   return os;
 }
 
 
 template <typename t_gapmer>
-std::ostream &operator<<(std::ostream &os,
-                         huddinge_neighbourhood<t_gapmer> const &hn) {
+std::ostream& operator<<(std::ostream& os,
+                         huddinge_neighbourhood<t_gapmer> const& hn) {
   os << "source: '" << hn.gd << "' values.size(): " << hn.values.size();
   return os;
 }
@@ -298,44 +296,52 @@ std::ostream &operator<<(std::ostream &os,
 namespace rc {
 
 template <>
-struct Arbitrary <gapmer_packed_input>
-{
-	static Gen <gapmer_packed_input> arbitrary()
-	{
-		return gen::mapcat(gen::arbitrary<gapmer_packed_input::text_type>(), [](gapmer_packed_input::text_type const &text) {
-			// We first generate the text, then based on its length kk, gap_start and gap_length one at a time.
-			// For some reason the integer values do not match if they are referenced (not copied) in the lambdas.
-			// Determine the length before moving below.
-			std::size_t const length{text.size()};
-			if (!length)
-				return gen::just(gapmer_packed_input{});
+struct Arbitrary<gapmer_packed_input> {
+  static Gen<gapmer_packed_input> arbitrary() {
+    return gen::mapcat(
+        gen::arbitrary<gapmer_packed_input::text_type>(),
+        [](gapmer_packed_input::text_type const& text) {
+          // We first generate the text, then based on its length kk, gap_start
+          // and gap_length one at a time. For some reason the integer values do
+          // not match if they are referenced (not copied) in the lambdas.
+          // Determine the length before moving below.
+          std::size_t const length{text.size()};
+          if (!length) return gen::just(gapmer_packed_input{});
 
-			if (1 == length)
-				return gen::just(gapmer_packed_input(text, 1));
+          if (1 == length) return gen::just(gapmer_packed_input(text, 1));
 
-			// Make sure that the gap length is meaningful by limiting the maximum k.
-			auto const make_k_gen{[&]{
-				std::uint8_t const length_limit(1 + libbio::min_ct(default_gapmer_type::max_k, (1 + length) / 2));
-				return gen::inRange(std::uint8_t{1}, length_limit);
-			}};
+          // Make sure that the gap length is meaningful by limiting the maximum
+          // k.
+          auto const make_k_gen{[&] {
+            std::uint8_t const length_limit(
+                1 +
+                libbio::min_ct(default_gapmer_type::max_k, (1 + length) / 2));
+            return gen::inRange(std::uint8_t{1}, length_limit);
+          }};
 
-			return gen::mapcat(make_k_gen(), [=, &text](std::uint8_t const kk) {
-				if (1 == kk)
-					return gen::just(gapmer_packed_input(text, 1));
+          return gen::mapcat(make_k_gen(), [=, &text](std::uint8_t const kk) {
+            if (1 == kk) return gen::just(gapmer_packed_input(text, 1));
 
-				std::uint8_t const gap_length_limit(libbio::min_ct(default_gapmer_type::max_gap, length - kk));
-				return gen::mapcat(gen::inRange(std::uint8_t{}, gap_length_limit), [=, &text](std::uint8_t const gap_length) {
-					if (0 == gap_length)
-						return gen::just(gapmer_packed_input{text, kk});
+            std::uint8_t const gap_length_limit(
+                libbio::min_ct(default_gapmer_type::max_gap, length - kk));
+            return gen::mapcat(
+                gen::inRange(std::uint8_t{}, gap_length_limit),
+                [=, &text](std::uint8_t const gap_length) {
+                  if (0 == gap_length)
+                    return gen::just(gapmer_packed_input{text, kk});
 
-					std::uint8_t const gap_start_limit(libbio::min_ct(kk, length - kk - gap_length + 1));
-					return gen::map(gen::inRange(std::uint8_t{1}, gap_start_limit), [=, &text](std::uint8_t const gap_start) {
-						return gapmer_packed_input{text, kk, gap_start, gap_length};
-					});
-				});
-			});
-		});
-	}
+                  std::uint8_t const gap_start_limit(
+                      libbio::min_ct(kk, length - kk - gap_length + 1));
+                  return gen::map(
+                      gen::inRange(std::uint8_t{1}, gap_start_limit),
+                      [=, &text](std::uint8_t const gap_start) {
+                        return gapmer_packed_input{text, kk, gap_start,
+                                                   gap_length};
+                      });
+                });
+          });
+        });
+  }
 };
 
 
@@ -620,7 +626,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
           str = gg.to_string();
           auto span(str.to_span());
 
-          auto const add_gapmer([&retval](string_buffer_type const &sb,
+          auto const add_gapmer([&retval](string_buffer_type const& sb,
                                           uint8_t const gap_start_,
                                           uint8_t const gap_length_) {
             // The constructor takes the number of defined characters as the
@@ -635,10 +641,10 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
             retval.values.insert(gg_);
           });
 
-          auto const modify_([&add_gapmer](string_buffer_type &sb,
+          auto const modify_([&add_gapmer](string_buffer_type& sb,
                                            uint8_t const gap_start_,
                                            uint8_t const gap_length_, auto it) {
-            auto &cc(*it);
+            auto& cc(*it);
             auto const orig_cc(cc);
             for (auto const cc_ : characters) {
               cc = cc_;
@@ -647,7 +653,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
             cc = orig_cc;
           });
 
-          auto const modify([&](string_buffer_type &sb,
+          auto const modify([&](string_buffer_type& sb,
                                 uint8_t const gap_start_,
                                 uint8_t const gap_length_, auto it, auto end) {
             while (it != end) {
@@ -656,7 +662,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
             }
           });
 
-          auto const extend_both([&modify_](string_buffer_type &sb,
+          auto const extend_both([&modify_](string_buffer_type& sb,
                                             uint8_t const gap_start_,
                                             uint8_t const gap_length_) {
             // Case 6.
@@ -679,7 +685,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
           });
 
           auto const extend_with_edge_gap_run(
-              [&modify_](string_buffer_type &sb) {
+              [&modify_](string_buffer_type& sb) {
                 // Case 7.
                 // Does not restore sb.
                 auto const orig_size(sb.size());
@@ -712,9 +718,8 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
               });
 
           auto const extend_middle_gap_both_ends(
-              [&modify_](string_buffer_type &sb,
-                                      uint8_t const gap_start_,
-                                      uint8_t const gap_length_) {
+              [&modify_](string_buffer_type& sb, uint8_t const gap_start_,
+                         uint8_t const gap_length_) {
                 // Case 4c.
                 switch (gap_length_) {
                   case 0:
@@ -820,7 +825,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
 
             case 1: {
               // Cases 4b and 2b.
-              auto &cc(*(span.begin() + gap_start));
+              auto& cc(*(span.begin() + gap_start));
               auto const orig_cc(cc);
               for (auto const cc_ : characters) {
                 cc = cc_;
@@ -859,7 +864,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
               extend_with_edge_gap_run(str_);
             } else {
               // Case 3a.
-              auto &cc(span[gap_start - 1]);
+              auto& cc(span[gap_start - 1]);
               auto const cc_(cc);
               cc = '.';
               if (gap_length < gapmer_type::max_gap)
@@ -894,7 +899,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
               extend_with_edge_gap_run(str_);
             } else {
               // Case 3a.
-              auto &cc(span[gap_start + gap_length]);
+              auto& cc(span[gap_start + gap_length]);
               auto const cc_(cc);
               cc = '.';
               if (gap_length < gapmer_type::max_gap)
@@ -984,7 +989,7 @@ struct Arbitrary<huddinge_neighbourhood_<t_gapmer_data>> {
 namespace sf {
 
 template <bool middle_gap_only, uint16_t t_max_gap>
-void showValue(gapmer<middle_gap_only, t_max_gap> const gg, std::ostream &os) {
+void showValue(gapmer<middle_gap_only, t_max_gap> const gg, std::ostream& os) {
   os << gg.to_string();
 }
 
@@ -1025,36 +1030,35 @@ SF_RC_TEST_WITH_BASE_CASE(gapmer_arbitrary, Constructors, gapmer_data,
 
 
 // FIXME: test other gapmer types.
-RC_GTEST_PROP(gapmer_arbitrary, FromPackedCharacterStringConstructor, (gapmer_packed_input const &test_input)) {
-	// Non-zero length required in gapmer’s constructor.
-	std::vector <std::uint64_t> plain_text(1 + (test_input.text.size() + 7) / 8, 0);
-	std::vector <std::uint64_t> packed_text(1 + (test_input.text.size() + 31) / 32, 0);
-	std::span plain_text_(reinterpret_cast <char *>(plain_text.data()), test_input.text.size());
+RC_GTEST_PROP(gapmer_arbitrary, FromPackedCharacterStringConstructor,
+              (gapmer_packed_input const& test_input)) {
+  typedef std::vector<std::uint64_t> vector_type;
+  // Non-zero length required in gapmer’s constructor.
+  vector_type plain_text(1 + (test_input.text.size() + 7) / 8, 0);
+  vector_type packed_text(1 + (test_input.text.size() + 31) / 32, 0);
+  std::span plain_text_(reinterpret_cast<char*>(plain_text.data()),
+                        test_input.text.size());
 
-	for (auto &&[lhs, rhs] : ranges::views::zip(test_input.text, plain_text_))
-		rhs = char(lhs);
+  // Assign the input characters to plain_text (via plain_text_).
+  for (auto&& [lhs, rhs] : ranges::views::zip(test_input.text, plain_text_))
+    rhs = char(lhs);
 
-	for (auto const &[ii, nt] : ranges::views::enumerate(test_input.text))
-	{
-		auto const word_idx{ii / 32};
-		auto const chr_idx{ii % 32};
-		std::uint64_t value{nt.value};
-		value <<= 62 - 2 * chr_idx;
-		packed_text[word_idx] |= value;
-	}
+  // Assign the input characters to packed_text.
+  auto const pack_res{sf::pack_characters(std::string_view{plain_text_}, packed_text, 0)};
+  EXPECT_EQ(pack_res, test_input.text.size());
 
-	RC_LOG() << "Plain text: ";
-	for (auto const cc : plain_text_)
-		RC_LOG() << cc;
-	RC_LOG() << '\n';
+  RC_LOG() << "Plain text: ";
+  for (auto const cc : plain_text_) RC_LOG() << cc;
+  RC_LOG() << '\n';
 
-	auto const expected([&]{
-		if (0 == test_input.kk)
-			return default_gapmer_type{};
-		return default_gapmer_type{plain_text.data(), test_input.kk, test_input.gap_start, test_input.gap_length};
-	}());
-	default_gapmer_type const actual{packed_text, test_input.kk, test_input.gap_start, test_input.gap_length};
-	EXPECT_EQ(expected, actual);
+  auto const expected([&] {
+    if (0 == test_input.kk) return default_gapmer_type{};
+    return default_gapmer_type{plain_text.data(), test_input.kk,
+                               test_input.gap_start, test_input.gap_length};
+  }());
+  default_gapmer_type const actual{packed_text, test_input.kk,
+                                   test_input.gap_start, test_input.gap_length};
+  EXPECT_EQ(expected, actual);
 }
 
 
@@ -1128,7 +1132,7 @@ SF_RC_TEST_WITH_BASE_CASE(gapmer_arbitrary, AlignEmptyGapmer, gapmer_data,
 
 
 RC_GTEST_PROP(gapmer_arbitrary, AlignNonemptyGapmer,
-              (aligning_gapmer_pair<> const &pair)) {
+              (aligning_gapmer_pair<> const& pair)) {
   SF_RC_TAG(pair.target.length, pair.target.gap_length);
 
   typedef aligning_gapmer_pair<>::gapmer_type gapmer_type;
@@ -1140,7 +1144,7 @@ RC_GTEST_PROP(gapmer_arbitrary, AlignNonemptyGapmer,
 
 
 SF_RC_TEMPLATE_TEST(gapmer_arbitrary_aligns_to, AlignNonMatchingGapmer,
-                    (TypeParam const &pair),
+                    (TypeParam const& pair),
                     non_aligning_gapmer_pair_value_mismatch<>,
                     non_aligning_gapmer_pair_source_length_greater<>) {
   SF_RC_TAG(pair.target.length, pair.target.gap_length);
@@ -1152,7 +1156,7 @@ SF_RC_TEMPLATE_TEST(gapmer_arbitrary_aligns_to, AlignNonMatchingGapmer,
 
 
 SF_RC_TEMPLATE_TEST(gapmer_arbitrary_aligns_to_reversible,
-                    AlignNonMatchingGapmerReversible, (TypeParam const &pair),
+                    AlignNonMatchingGapmerReversible, (TypeParam const& pair),
                     non_aligning_gapmer_pair_gap_length_mismatch<>,
                     non_aligning_gapmer_pair_gap_position_mismatch<>) {
   SF_RC_TAG(pair.target.length, pair.target.gap_length);
@@ -1186,7 +1190,7 @@ typedef huddinge_neighbourhood<
 
 SF_RC_TEST_PROP(gapmer_arbitrary, GenerateHuddingeNeighbourhood,
                 gapmer_arbitrary_huddinge_neighbourhood_test_type,
-                gapmer_arbitrary_huddinge_neighbourhood_result_type const &hn,
+                gapmer_arbitrary_huddinge_neighbourhood_result_type const& hn,
                 (hn.gd.length, hn.gd.gap_length)) {
   typedef gapmer_arbitrary_huddinge_neighbourhood_gapmer_type
       gapmer_type;  // FIXME: Use a type parameter here.

--- a/test/gapmer_tests.hpp
+++ b/test/gapmer_tests.hpp
@@ -606,7 +606,7 @@ TEST(gapmer, Align5) {
   auto vec = vec_from_string(s);
   gapmer<true, 5> g(vec.data(), 9, 4, 3);
   gapmer<true, 5> o(vec.data(), 12);
-  bool res = g.template aligns_to(o);
+  bool res = g.template aligns_to<>(o);
   ASSERT_TRUE(res);
 }
 

--- a/test/nucleotide.hpp
+++ b/test/nucleotide.hpp
@@ -8,78 +8,87 @@
 #include <cstdint>
 #include <ostream>
 #include <stdexcept>
+
 #include "test.hpp"
 
 
 namespace {
 
-	struct nucleotide
-	{
-		char value{};
+struct nucleotide {
+  char value{};
 
-		/* implicit */ operator char() const { return value; }
-	};
-
-
-	struct packed_nucleotide
-	{
-		std::uint8_t value{};
-
-		/* implicit */ inline operator char() const;
-	};
+  /* implicit */ operator char() const { return value; }
+};
 
 
-	packed_nucleotide::operator char() const
-	{
-		switch (value)
-		{
-			case 0x0: return 'A';
-			case 0x1: return 'C';
-			case 0x2: return 'G';
-			case 0x3: return 'T';
-			default: throw std::runtime_error{"Unexpected packed value"};
-		}
-	}
+struct packed_nucleotide {
+  std::uint8_t value{};
+
+  /* implicit */ inline operator char() const;
+};
 
 
-	inline std::ostream &operator<<(std::ostream &os, nucleotide const nt) { os << char(nt); return os; }
-	inline std::ostream &operator<<(std::ostream &os, packed_nucleotide const nt) { os << char(nt); return os; }
-
-
-	char complement_nt(char const cc)
-	{
-		switch (cc)
-		{
-			case 'A': return 'T';
-			case 'C': return 'G';
-			case 'G': return 'C';
-			case 'T': return 'A';
-			case '.': return '.';
-			default:
-				throw std::runtime_error("Unexpected character");
-		}
-	}
+packed_nucleotide::operator char() const {
+  switch (value) {
+    case 0x0:
+      return 'A';
+    case 0x1:
+      return 'C';
+    case 0x2:
+      return 'G';
+    case 0x3:
+      return 'T';
+    default:
+      throw std::runtime_error{"Unexpected packed value"};
+  }
 }
+
+
+inline std::ostream& operator<<(std::ostream& os, nucleotide const nt) {
+  os << char(nt);
+  return os;
+}
+inline std::ostream& operator<<(std::ostream& os, packed_nucleotide const nt) {
+  os << char(nt);
+  return os;
+}
+
+
+char complement_nt(char const cc) {
+  switch (cc) {
+    case 'A':
+      return 'T';
+    case 'C':
+      return 'G';
+    case 'G':
+      return 'C';
+    case 'T':
+      return 'A';
+    case '.':
+      return '.';
+    default:
+      throw std::runtime_error("Unexpected character");
+  }
+}
+}  // namespace
 
 
 namespace rc {
 
-	template <>
-	struct Arbitrary <packed_nucleotide>
-	{
-		static Gen <packed_nucleotide> arbitrary()
-		{
-			return gen::construct <packed_nucleotide>(gen::inRange(std::uint8_t{}, std::uint8_t{0x4})); // Half-open range.
-		}
-	};
+template <>
+struct Arbitrary<packed_nucleotide> {
+  static Gen<packed_nucleotide> arbitrary() {
+    return gen::construct<packed_nucleotide>(
+        gen::inRange(std::uint8_t{}, std::uint8_t{0x4})); // Half-open range.
+  }
+};
 
 
-	template <>
-	struct Arbitrary <nucleotide>
-	{
-		static Gen <nucleotide> arbitrary()
-		{
-			return gen::map(gen::arbitrary <packed_nucleotide>(), [](auto const pn){ return nucleotide(pn); });
-		}
-	};
-}
+template <>
+struct Arbitrary<nucleotide> {
+  static Gen<nucleotide> arbitrary() {
+    return gen::map(gen::arbitrary<packed_nucleotide>(),
+                    [](auto const pn) { return nucleotide(pn); });
+  }
+};
+}  // namespace rc

--- a/test/nucleotide.hpp
+++ b/test/nucleotide.hpp
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <ostream>
+#include <stdexcept>
 #include "test.hpp"
 
 
@@ -16,6 +19,31 @@ namespace {
 
 		/* implicit */ operator char() const { return value; }
 	};
+
+
+	struct packed_nucleotide
+	{
+		std::uint8_t value{};
+
+		/* implicit */ inline operator char() const;
+	};
+
+
+	packed_nucleotide::operator char() const
+	{
+		switch (value)
+		{
+			case 0x0: return 'A';
+			case 0x1: return 'C';
+			case 0x2: return 'G';
+			case 0x3: return 'T';
+			default: throw std::runtime_error{"Unexpected packed value"};
+		}
+	}
+
+
+	inline std::ostream &operator<<(std::ostream &os, nucleotide const nt) { os << char(nt); return os; }
+	inline std::ostream &operator<<(std::ostream &os, packed_nucleotide const nt) { os << char(nt); return os; }
 
 
 	char complement_nt(char const cc)
@@ -37,14 +65,21 @@ namespace {
 namespace rc {
 
 	template <>
+	struct Arbitrary <packed_nucleotide>
+	{
+		static Gen <packed_nucleotide> arbitrary()
+		{
+			return gen::construct <packed_nucleotide>(gen::inRange(std::uint8_t{}, std::uint8_t{0x4})); // Half-open range.
+		}
+	};
+
+
+	template <>
 	struct Arbitrary <nucleotide>
 	{
 		static Gen <nucleotide> arbitrary()
 		{
-			constexpr static std::array const values{'A', 'C', 'G', 'T'};
-			return gen::map(gen::elementOf(values), [](auto const cc) -> nucleotide {
-				return {cc};
-			});
+			return gen::map(gen::arbitrary <packed_nucleotide>(), [](auto const pn){ return nucleotide(pn); });
 		}
 	};
 }

--- a/test/pack_characters_arbitrary.hpp
+++ b/test/pack_characters_arbitrary.hpp
@@ -1,0 +1,53 @@
+#include <cstdint>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/for_each.hpp>
+#include <range/v3/view/zip.hpp>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "nucleotide.hpp"
+#include "test.hpp"
+
+#include "../include/libbio_reader_adapter.hpp"
+
+
+RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack, (std::vector <std::vector <nucleotide>> const &text))
+{
+	{
+		auto const total_length{[&]{
+			std::uint64_t retval{};
+			for (auto const &vec : text)
+				retval += vec.size();
+			return retval;
+		}()};
+		RC_TAG(text.size(), total_length);
+	}
+
+	std::vector <std::uint64_t> packed;
+	std::string unpacked;
+
+	std::string buffer;
+	std::uint64_t pos{};
+
+	// Pack the characters.
+	for (auto const &vec : text)
+	{
+		buffer.clear();
+		for (auto const nt : vec)
+			buffer.push_back(char(nt));
+
+		pos = sf::pack_characters(buffer, packed, pos);
+		EXPECT_NE(UINT64_MAX, pos);
+	}
+
+	// Unpack.
+	sf::unpack_characters(packed, pos, unpacked);
+
+	// Flatten the range.
+	auto rng{ranges::views::for_each(text, [](auto const &vec){
+		return ranges::views::all(vec);
+	})};
+
+	for (auto const &[lhs, rhs] : ranges::views::zip(rng, unpacked))
+		EXPECT_EQ(lhs, rhs);
+}

--- a/test/pack_characters_arbitrary.hpp
+++ b/test/pack_characters_arbitrary.hpp
@@ -14,6 +14,7 @@
 RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack,
               (std::vector<std::vector<nucleotide>> const& text)) {
   {
+    // Determine the sum of the lengths of the input texts.
     auto const total_length{[&] {
       std::uint64_t retval{};
       for (auto const& vec : text) retval += vec.size();
@@ -40,10 +41,13 @@ RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack,
   // Unpack.
   sf::unpack_characters(packed, pos, unpacked);
 
-  // Flatten the range.
+  // Since the input consists of multiple vectors of characters,
+  // we flatten the enclosing range so that we can compare the
+  // unpacked value (above) to the input character by character.
   auto rng{ranges::views::for_each(
       text, [](auto const& vec) { return ranges::views::all(vec); })};
 
+  // Compare character by character.
   for (auto const& [lhs, rhs] : ranges::views::zip(rng, unpacked))
     EXPECT_EQ(lhs, rhs);
 }

--- a/test/pack_characters_arbitrary.hpp
+++ b/test/pack_characters_arbitrary.hpp
@@ -28,7 +28,7 @@ RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack,
   std::string buffer;
   std::uint64_t pos{};
 
-        // Pack the characters.
+  // Pack the characters.
   for (auto const& vec : text) {
     buffer.clear();
     for (auto const nt : vec) buffer.push_back(char(nt));
@@ -37,10 +37,10 @@ RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack,
     EXPECT_NE(UINT64_MAX, pos);
   }
 
-        // Unpack.
+  // Unpack.
   sf::unpack_characters(packed, pos, unpacked);
 
-        // Flatten the range.
+  // Flatten the range.
   auto rng{ranges::views::for_each(
       text, [](auto const& vec) { return ranges::views::all(vec); })};
 

--- a/test/pack_characters_arbitrary.hpp
+++ b/test/pack_characters_arbitrary.hpp
@@ -4,50 +4,46 @@
 #include <range/v3/view/zip.hpp>
 #include <string>
 #include <vector>
+
+#include "../include/libbio_reader_adapter.hpp"
 #include "gtest/gtest.h"
 #include "nucleotide.hpp"
 #include "test.hpp"
 
-#include "../include/libbio_reader_adapter.hpp"
 
+RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack,
+              (std::vector<std::vector<nucleotide>> const& text)) {
+  {
+    auto const total_length{[&] {
+      std::uint64_t retval{};
+      for (auto const& vec : text) retval += vec.size();
+      return retval;
+    }()};
+    RC_TAG(text.size(), total_length);
+  }
 
-RC_GTEST_PROP(pack_characters_arbitrary, PackAndUnpack, (std::vector <std::vector <nucleotide>> const &text))
-{
-	{
-		auto const total_length{[&]{
-			std::uint64_t retval{};
-			for (auto const &vec : text)
-				retval += vec.size();
-			return retval;
-		}()};
-		RC_TAG(text.size(), total_length);
-	}
+  std::vector<std::uint64_t> packed;
+  std::string unpacked;
 
-	std::vector <std::uint64_t> packed;
-	std::string unpacked;
+  std::string buffer;
+  std::uint64_t pos{};
 
-	std::string buffer;
-	std::uint64_t pos{};
+        // Pack the characters.
+  for (auto const& vec : text) {
+    buffer.clear();
+    for (auto const nt : vec) buffer.push_back(char(nt));
 
-	// Pack the characters.
-	for (auto const &vec : text)
-	{
-		buffer.clear();
-		for (auto const nt : vec)
-			buffer.push_back(char(nt));
+    pos = sf::pack_characters(buffer, packed, pos);
+    EXPECT_NE(UINT64_MAX, pos);
+  }
 
-		pos = sf::pack_characters(buffer, packed, pos);
-		EXPECT_NE(UINT64_MAX, pos);
-	}
+        // Unpack.
+  sf::unpack_characters(packed, pos, unpacked);
 
-	// Unpack.
-	sf::unpack_characters(packed, pos, unpacked);
+        // Flatten the range.
+  auto rng{ranges::views::for_each(
+      text, [](auto const& vec) { return ranges::views::all(vec); })};
 
-	// Flatten the range.
-	auto rng{ranges::views::for_each(text, [](auto const &vec){
-		return ranges::views::all(vec);
-	})};
-
-	for (auto const &[lhs, rhs] : ranges::views::zip(rng, unpacked))
-		EXPECT_EQ(lhs, rhs);
+  for (auto const& [lhs, rhs] : ranges::views::zip(rng, unpacked))
+    EXPECT_EQ(lhs, rhs);
 }

--- a/test/packed_character_iteration_arbitrary.hpp
+++ b/test/packed_character_iteration_arbitrary.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/zip.hpp>
+#include <span>
+#include <utility>
+#include <vector>
+#include "../include/packed_character_iteration.hpp"
+#include "test.hpp"
+#include "nucleotide.hpp"
+
+// FIXME: Some of the types used in the tests need to have typedefs for the
+// associated types since the preprocessor has difficulties with commas as part
+// of the type names. Some of the typedefs have very long names in order to
+// encode the name of the test they have to do with. Separating the tests into
+// multiple translation units could help with this.
+
+namespace {
+
+	typedef std::vector <packed_nucleotide> packed_nucleotide_vector;
+
+
+	struct packed_character_iteration_test_input
+	{
+		packed_nucleotide_vector text;
+		std::size_t start_pos{};
+	};
+
+
+	struct packed_character_pair_iteration_test_input
+	{
+		packed_nucleotide_vector text;
+		std::size_t lhs{};
+		std::size_t rhs{};
+	};
+
+
+	std::vector <std::uint64_t> packed_text(packed_nucleotide_vector const &src)
+	{
+		sf::packed_word_vector retval((src.size() + 31U) / 32U, 0);
+		std::uint64_t pos{};
+		for (auto const nt : src)
+		{
+			auto const word_idx{pos / 32U};
+			auto const chr_idx{pos % 32U};
+			std::uint64_t nt_(nt.value);
+			nt_ <<= 62U - 2U * chr_idx;
+			retval.at(word_idx) |= nt_; // Bounds check for extra safety.
+			++pos;
+		}
+
+		return retval;
+	}
+
+
+	template <typename t_cb>
+	void iterate_packed_charaters(packed_character_pair_iteration_test_input const &input, t_cb &&cb)
+	{
+		RC_ASSERT(0 == input.rhs || input.lhs < input.rhs);
+		std::size_t const count{input.text.size() - input.rhs};
+		for (std::size_t ii{}; ii < count; ++ii)
+			cb(input.text[input.lhs + ii], input.text[input.rhs + ii]);
+	}
+
+
+	std::ostream &operator<<(std::ostream &os, packed_character_iteration_test_input const &input)
+	{
+		os << "text: ";
+		for (auto const cc : input.text)
+			os << nucleotide(cc);
+		os << " start_pos: " << input.start_pos;
+		return os;
+	}
+
+
+	std::ostream &operator<<(std::ostream &os, packed_character_pair_iteration_test_input const &input)
+	{
+		os << "text: ";
+		for (auto const cc : input.text)
+			os << nucleotide(cc);
+		os << " lhs: " << input.lhs << " rhs: " << input.rhs;
+		return os;
+	}
+}
+
+
+namespace rc {
+
+	template <>
+	struct Arbitrary <packed_character_iteration_test_input>
+	{
+		static Gen <packed_character_iteration_test_input> arbitrary()
+		{
+			return gen::mapcat(gen::arbitrary <std::vector <packed_nucleotide>>(), [](std::vector <packed_nucleotide> &&text){
+				std::size_t const length{text.size()}; // Determine the length before moving below.
+				return gen::construct <packed_character_iteration_test_input>(
+					gen::just(std::move(text)),
+					length ? gen::inRange(std::size_t{}, length) : gen::just(length) // Half-open range.
+				);
+			});
+		}
+	};
+
+
+	template <>
+	struct Arbitrary <packed_character_pair_iteration_test_input>
+	{
+		static Gen <packed_character_pair_iteration_test_input> arbitrary()
+		{
+			return gen::mapcat(gen::arbitrary <std::vector <packed_nucleotide>>(), [](std::vector <packed_nucleotide> &&text){
+				std::size_t const length{text.size()}; // Determine the length before moving below.
+				if (!length)
+					return gen::just(packed_character_pair_iteration_test_input{});
+
+				return gen::mapcat(1U < length ? gen::inRange(std::size_t{1U}, length) : gen::just(std::size_t{1}), [text = std::move(text)](auto const rhs){ // Half-open range.
+					return gen::construct <packed_character_pair_iteration_test_input>(
+						gen::just(std::move(text)),
+						gen::inRange(std::size_t{}, rhs), // Half-open range.
+						gen::just(rhs)
+					);
+				});
+			});
+		}
+	};
+}
+
+
+namespace {
+
+	RC_GTEST_PROP(packed_character_iteration_arbitrary, IterateSingle, (packed_character_iteration_test_input const &input))
+	{
+		SF_RC_TAG(input.text.size());
+
+		std::vector <nucleotide> expected;
+		std::vector <nucleotide> actual;
+
+		{
+			auto const span(std::span(input.text.begin(), input.text.end()).subspan(input.start_pos));
+			for (auto nt : span)
+				expected.emplace_back(nt);
+		}
+
+		auto const packed_text_{packed_text(input.text)};
+		sf::iterate_packed_characters(packed_text_, input.text.size(), input.start_pos, [&](auto const cc){
+			actual.emplace_back(packed_nucleotide(cc));
+		});
+
+		RC_ASSERT(expected == actual);
+	}
+
+
+	RC_GTEST_PROP(packed_character_iteration_arbitrary, IteratePairs, (packed_character_pair_iteration_test_input const &input))
+	{
+		SF_RC_TAG(input.text.size());
+
+		std::vector <nucleotide> expected;
+		std::vector <nucleotide> actual;
+
+		iterate_packed_charaters(input, [&](auto const lhsc, auto const rhsc){
+			expected.emplace_back(lhsc);
+			expected.emplace_back(rhsc);
+		});
+
+		auto const packed_text_{packed_text(input.text)};
+		sf::iterate_packed_character_pairs(packed_text_, input.text.size(), input.lhs, input.rhs, [&](auto const lhsc, auto const rhsc){
+			actual.emplace_back(packed_nucleotide(lhsc));
+			actual.emplace_back(packed_nucleotide(rhsc));
+		});
+
+		RC_LOG() << "Character pairs (expected length " << expected.size() << ", actual length " << actual.size() << "):\n";
+		for (auto const &[idx, tup] : ranges::views::zip(expected, actual) | ranges::views::enumerate)
+		{
+			auto const &[ec, ac] = tup;
+			RC_LOG() << idx << ":\t" << ec << ' ' << ac;
+			if (ec != ac)
+				RC_LOG() << " mismatch";
+			RC_LOG() << '\n';
+		}
+
+		RC_ASSERT(expected == actual);
+	}
+}

--- a/test/packed_character_iteration_arbitrary.hpp
+++ b/test/packed_character_iteration_arbitrary.hpp
@@ -7,9 +7,10 @@
 #include <span>
 #include <utility>
 #include <vector>
+
 #include "../include/packed_character_iteration.hpp"
-#include "test.hpp"
 #include "nucleotide.hpp"
+#include "test.hpp"
 
 // FIXME: Some of the types used in the tests need to have typedefs for the
 // associated types since the preprocessor has difficulties with commas as part
@@ -19,166 +20,168 @@
 
 namespace {
 
-	typedef std::vector <packed_nucleotide> packed_nucleotide_vector;
+typedef std::vector<packed_nucleotide> packed_nucleotide_vector;
 
 
-	struct packed_character_iteration_test_input
-	{
-		packed_nucleotide_vector text;
-		std::size_t start_pos{};
-	};
+struct packed_character_iteration_test_input {
+  packed_nucleotide_vector text;
+  std::size_t start_pos{};
+};
 
 
-	struct packed_character_pair_iteration_test_input
-	{
-		packed_nucleotide_vector text;
-		std::size_t lhs{};
-		std::size_t rhs{};
-	};
+struct packed_character_pair_iteration_test_input {
+  packed_nucleotide_vector text;
+  std::size_t lhs{};
+  std::size_t rhs{};
+};
 
 
-	std::vector <std::uint64_t> packed_text(packed_nucleotide_vector const &src)
-	{
-		sf::packed_word_vector retval((src.size() + 31U) / 32U, 0);
-		std::uint64_t pos{};
-		for (auto const nt : src)
-		{
-			auto const word_idx{pos / 32U};
-			auto const chr_idx{pos % 32U};
-			std::uint64_t nt_(nt.value);
-			nt_ <<= 62U - 2U * chr_idx;
-			retval.at(word_idx) |= nt_; // Bounds check for extra safety.
-			++pos;
-		}
+std::vector<std::uint64_t> packed_text(packed_nucleotide_vector const& src) {
+  sf::packed_word_vector retval((src.size() + 31U) / 32U, 0);
+  std::uint64_t pos{};
+  for (auto const nt : src) {
+    auto const word_idx{pos / 32U};
+    auto const chr_idx{pos % 32U};
+    std::uint64_t nt_(nt.value);
+    nt_ <<= 62U - 2U * chr_idx;
+    retval.at(word_idx) |= nt_; // Bounds check for extra safety.
+    ++pos;
+  }
 
-		return retval;
-	}
-
-
-	template <typename t_cb>
-	void iterate_packed_charaters(packed_character_pair_iteration_test_input const &input, t_cb &&cb)
-	{
-		RC_ASSERT(0 == input.rhs || input.lhs < input.rhs);
-		std::size_t const count{input.text.size() - input.rhs};
-		for (std::size_t ii{}; ii < count; ++ii)
-			cb(input.text[input.lhs + ii], input.text[input.rhs + ii]);
-	}
-
-
-	std::ostream &operator<<(std::ostream &os, packed_character_iteration_test_input const &input)
-	{
-		os << "text: ";
-		for (auto const cc : input.text)
-			os << nucleotide(cc);
-		os << " start_pos: " << input.start_pos;
-		return os;
-	}
-
-
-	std::ostream &operator<<(std::ostream &os, packed_character_pair_iteration_test_input const &input)
-	{
-		os << "text: ";
-		for (auto const cc : input.text)
-			os << nucleotide(cc);
-		os << " lhs: " << input.lhs << " rhs: " << input.rhs;
-		return os;
-	}
+  return retval;
 }
+
+
+template <typename t_cb>
+void iterate_packed_charaters(
+    packed_character_pair_iteration_test_input const& input, t_cb&& cb) {
+  RC_ASSERT(0 == input.rhs || input.lhs < input.rhs);
+  std::size_t const count{input.text.size() - input.rhs};
+  for (std::size_t ii{}; ii < count; ++ii)
+    cb(input.text[input.lhs + ii], input.text[input.rhs + ii]);
+}
+
+
+std::ostream& operator<<(std::ostream& os,
+                         packed_character_iteration_test_input const& input) {
+  os << "text: ";
+  for (auto const cc : input.text) os << nucleotide(cc);
+  os << " start_pos: " << input.start_pos;
+  return os;
+}
+
+
+std::ostream& operator<<(
+    std::ostream& os, packed_character_pair_iteration_test_input const& input) {
+  os << "text: ";
+  for (auto const cc : input.text) os << nucleotide(cc);
+  os << " lhs: " << input.lhs << " rhs: " << input.rhs;
+  return os;
+}
+}  // namespace
 
 
 namespace rc {
 
-	template <>
-	struct Arbitrary <packed_character_iteration_test_input>
-	{
-		static Gen <packed_character_iteration_test_input> arbitrary()
-		{
-			return gen::mapcat(gen::arbitrary <std::vector <packed_nucleotide>>(), [](std::vector <packed_nucleotide> &&text){
-				std::size_t const length{text.size()}; // Determine the length before moving below.
-				return gen::construct <packed_character_iteration_test_input>(
-					gen::just(std::move(text)),
-					length ? gen::inRange(std::size_t{}, length) : gen::just(length) // Half-open range.
-				);
-			});
-		}
-	};
+template <>
+struct Arbitrary<packed_character_iteration_test_input> {
+  static Gen<packed_character_iteration_test_input> arbitrary() {
+    return gen::mapcat(
+        gen::arbitrary<std::vector<packed_nucleotide>>(),
+        [](std::vector<packed_nucleotide>&& text) {
+          std::size_t const length{
+              text.size()}; // Determine the length before moving below.
+          return gen::construct<packed_character_iteration_test_input>(
+              gen::just(std::move(text)),
+              length ? gen::inRange(std::size_t{}, length)
+                     : gen::just(length) // Half-open range.
+          );
+        });
+  }
+};
 
 
-	template <>
-	struct Arbitrary <packed_character_pair_iteration_test_input>
-	{
-		static Gen <packed_character_pair_iteration_test_input> arbitrary()
-		{
-			return gen::mapcat(gen::arbitrary <std::vector <packed_nucleotide>>(), [](std::vector <packed_nucleotide> &&text){
-				std::size_t const length{text.size()}; // Determine the length before moving below.
-				if (!length)
-					return gen::just(packed_character_pair_iteration_test_input{});
+template <>
+struct Arbitrary<packed_character_pair_iteration_test_input> {
+  static Gen<packed_character_pair_iteration_test_input> arbitrary() {
+    return gen::mapcat(
+        gen::arbitrary<std::vector<packed_nucleotide>>(),
+        [](std::vector<packed_nucleotide>&& text) {
+          std::size_t const length{
+              text.size()}; // Determine the length before moving below.
+          if (!length)
+            return gen::just(packed_character_pair_iteration_test_input{});
 
-				return gen::mapcat(1U < length ? gen::inRange(std::size_t{1U}, length) : gen::just(std::size_t{1}), [text = std::move(text)](auto const rhs){ // Half-open range.
-					return gen::construct <packed_character_pair_iteration_test_input>(
-						gen::just(std::move(text)),
-						gen::inRange(std::size_t{}, rhs), // Half-open range.
-						gen::just(rhs)
-					);
-				});
-			});
-		}
-	};
-}
+          return gen::mapcat(
+              1U < length ? gen::inRange(std::size_t{1U}, length)
+                          : gen::just(std::size_t{1}),
+              [text = std::move(text)](auto const rhs) { // Half-open range.
+                return gen::construct<
+                    packed_character_pair_iteration_test_input>(
+                    gen::just(std::move(text)),
+                    gen::inRange(std::size_t{}, rhs), // Half-open range.
+                    gen::just(rhs));
+              });
+        });
+  }
+};
+}  // namespace rc
 
 
 namespace {
 
-	RC_GTEST_PROP(packed_character_iteration_arbitrary, IterateSingle, (packed_character_iteration_test_input const &input))
-	{
-		SF_RC_TAG(input.text.size());
+RC_GTEST_PROP(packed_character_iteration_arbitrary, IterateSingle,
+              (packed_character_iteration_test_input const& input)) {
+  SF_RC_TAG(input.text.size());
 
-		std::vector <nucleotide> expected;
-		std::vector <nucleotide> actual;
+  std::vector<nucleotide> expected;
+  std::vector<nucleotide> actual;
 
-		{
-			auto const span(std::span(input.text.begin(), input.text.end()).subspan(input.start_pos));
-			for (auto nt : span)
-				expected.emplace_back(nt);
-		}
+  {
+    auto const span(std::span(input.text.begin(), input.text.end())
+                        .subspan(input.start_pos));
+    for (auto nt : span) expected.emplace_back(nt);
+  }
 
-		auto const packed_text_{packed_text(input.text)};
-		sf::iterate_packed_characters(packed_text_, input.text.size(), input.start_pos, [&](auto const cc){
-			actual.emplace_back(packed_nucleotide(cc));
-		});
+  auto const packed_text_{packed_text(input.text)};
+  sf::iterate_packed_characters(
+      packed_text_, input.text.size(), input.start_pos,
+      [&](auto const cc) { actual.emplace_back(packed_nucleotide(cc)); });
 
-		RC_ASSERT(expected == actual);
-	}
-
-
-	RC_GTEST_PROP(packed_character_iteration_arbitrary, IteratePairs, (packed_character_pair_iteration_test_input const &input))
-	{
-		SF_RC_TAG(input.text.size());
-
-		std::vector <nucleotide> expected;
-		std::vector <nucleotide> actual;
-
-		iterate_packed_charaters(input, [&](auto const lhsc, auto const rhsc){
-			expected.emplace_back(lhsc);
-			expected.emplace_back(rhsc);
-		});
-
-		auto const packed_text_{packed_text(input.text)};
-		sf::iterate_packed_character_pairs(packed_text_, input.text.size(), input.lhs, input.rhs, [&](auto const lhsc, auto const rhsc){
-			actual.emplace_back(packed_nucleotide(lhsc));
-			actual.emplace_back(packed_nucleotide(rhsc));
-		});
-
-		RC_LOG() << "Character pairs (expected length " << expected.size() << ", actual length " << actual.size() << "):\n";
-		for (auto const &[idx, tup] : ranges::views::zip(expected, actual) | ranges::views::enumerate)
-		{
-			auto const &[ec, ac] = tup;
-			RC_LOG() << idx << ":\t" << ec << ' ' << ac;
-			if (ec != ac)
-				RC_LOG() << " mismatch";
-			RC_LOG() << '\n';
-		}
-
-		RC_ASSERT(expected == actual);
-	}
+  RC_ASSERT(expected == actual);
 }
+
+
+RC_GTEST_PROP(packed_character_iteration_arbitrary, IteratePairs,
+              (packed_character_pair_iteration_test_input const& input)) {
+  SF_RC_TAG(input.text.size());
+
+  std::vector<nucleotide> expected;
+  std::vector<nucleotide> actual;
+
+  iterate_packed_charaters(input, [&](auto const lhsc, auto const rhsc) {
+    expected.emplace_back(lhsc);
+    expected.emplace_back(rhsc);
+  });
+
+  auto const packed_text_{packed_text(input.text)};
+  sf::iterate_packed_character_pairs(
+      packed_text_, input.text.size(), input.lhs, input.rhs,
+      [&](auto const lhsc, auto const rhsc) {
+        actual.emplace_back(packed_nucleotide(lhsc));
+        actual.emplace_back(packed_nucleotide(rhsc));
+      });
+
+  RC_LOG() << "Character pairs (expected length " << expected.size()
+           << ", actual length " << actual.size() << "):\n";
+  for (auto const& [idx, tup] :
+       ranges::views::zip(expected, actual) | ranges::views::enumerate) {
+    auto const& [ec, ac] = tup;
+    RC_LOG() << idx << ":\t" << ec << ' ' << ac;
+    if (ec != ac) RC_LOG() << " mismatch";
+    RC_LOG() << '\n';
+  }
+
+  RC_ASSERT(expected == actual);
+}
+}  // namespace

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -21,3 +21,4 @@
 #include "gapmer_count_tests.hpp"
 
 #include "packed_character_iteration_arbitrary.hpp"
+#include "pack_characters_arbitrary.hpp"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -19,3 +19,5 @@
 
 // kmer counter tests
 #include "gapmer_count_tests.hpp"
+
+#include "iterate_packed_characters_arbitrary.hpp"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -20,4 +20,4 @@
 // kmer counter tests
 #include "gapmer_count_tests.hpp"
 
-#include "iterate_packed_characters_arbitrary.hpp"
+#include "packed_character_iteration_arbitrary.hpp"

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -47,6 +47,7 @@ namespace sf {
 // Mainly for checking if empty parentheses are passed in place of a macro parameter.
 // We could detect this with __VA_OPT__ but since it is fairly new, we use the GCC extension
 // which causes the comma in , ##__VA_ARGS__ to be deleted if __VA_ARGS__ is empty.
+// FIXME: __VA_OPT__ is available in GCC 8.5.0 (or so) even in C++17 mode.
 #define SF_NARGS_(_0, _16, _15, _14, _13, _12, _11, _10, _9, _8, _7, _6, _5, _4, _3, _2, _1, N, ...) N
 #define SF_NARGS(...) SF_NARGS_(0, ##__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 


### PR DESCRIPTION
* Added an interface for fetching the reads from the input, `reader_adapter`.
* Currently the FASTA/Q parser in use is the one from SeqIO, since libbio’s parser did not seem to affect performance in any way. I think we should switch, though, since the latter validates the input. The downside is that [Ragel](https://www.colm.net/open-source/ragel/) is needed to build libbio.
* Wildcards are now handled by discarding the reads per Kimmo’s suggestion (please see #23). I’ll add the functionality to make use of the reads where possible as soon as I can.
* Names of the input files with skipped reads are also printed to stderr. When libbio’s parsers are used, the line numbers are also printed.
* gapmers are now constructed from packed characters. I made this change mostly because libbio’s parsers pass `std::string_view`s instead of copying the input and hence packing the characters while parsing made sense. I decided to keep it anyway since gapmer’s constructors expect valid inputs. 
* This also fixes the bug which caused wildcard characters to be replaced with various characters depending on the situation including A and G.
* Some header-only functionality from libbio is now used so added it as a dependency.
* Applied conventional variable names to Makefile.